### PR TITLE
feat(skills): add ask plugin skills for docs management

### DIFF
--- a/skills/add-docs/SKILL.md
+++ b/skills/add-docs/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: add-docs
+description: >
+  Download a single library's documentation and wire it into the project so AI agents
+  can read accurate, version-specific docs instead of relying on training data. Mirrors
+  the `ask docs add <spec>` CLI command but runs entirely as agent steps — no CLI binary
+  required. Resolves the best source via the ASK Registry (priority: github > npm > web >
+  llms-txt), falls back to package-manager metadata when the registry has no entry, saves
+  files to `.ask/docs/<name>@<version>/`, updates `.ask/config.json`, and refreshes
+  the auto-generated block in `AGENTS.md`. MUST use this skill whenever the user asks to
+  add docs for a specific library (e.g. "zod 문서 추가", "add docs for next@canary",
+  "ask docs add ..."), introduces a new dependency, or upgrades a single package and
+  wants its docs refreshed. Trigger on: "문서 추가", "docs 추가", "add docs", "ask docs add",
+  "라이브러리 문서 받아", "fetch docs for", and any mention of pulling a single library's
+  documentation into the project.
+---
+
+# add-docs — Add a Single Library's Documentation
+
+Download docs for one library and register them so AI agents (Claude Code, Cursor, etc.)
+can read them via `AGENTS.md`. This is the canonical pipeline; `setup-docs` and `sync-docs`
+both reuse the steps in this file.
+
+## When to use this skill
+
+- The user names a library (with or without version) and asks to fetch its docs.
+- A new dependency was just added and you want its docs available before writing code.
+- A single package was upgraded and its docs need to be refreshed.
+
+For batch initial setup of every dependency, use `setup-docs` instead.
+For drift detection after lockfile changes, use `sync-docs`.
+
+## Inputs
+
+- **spec** (required) — `<name>[@version]`, optionally with an ecosystem prefix:
+  - `zod` — name only, version resolved to `latest` from the chosen source
+  - `zod@3.22` — explicit version
+  - `npm:next@canary` — explicit ecosystem + tag
+  - `pypi:fastapi`, `go:github.com/gin-gonic/gin`, `crates:serde`, `hex:phoenix`, `pub:dio`
+- **source override** (optional) — if the user pins one of `github`, `npm`, `web`, `llms-txt`,
+  honor it and skip the registry lookup. Otherwise auto-resolve.
+- **explicit hints** (optional) — `repo` (for github), `url` (for web/llms-txt), `branch`/`tag`,
+  `docsPath`, `maxDepth`, `pathPrefix`. Pass-through to the source step.
+
+## Pipeline overview
+
+```
+parse → detect ecosystem → registry lookup → (fallback) → fetch docs
+      → save to .ask/docs → update .ask/config.json → update .ask/ask.lock
+      → update AGENTS.md (marker block) → ensure CLAUDE.md @AGENTS.md
+```
+
+The order matters: each later step assumes the previous one succeeded.
+
+---
+
+## Step 1 — Parse the spec
+
+Split off the optional ecosystem prefix at the first `:`. Whatever's left is `name[@version]`.
+Take the **last** `@` as the version separator (so scoped npm names like `@scope/pkg@1.2`
+still parse correctly). If no version is given, treat it as `latest` and let the source
+report the resolved version.
+
+## Step 2 — Detect ecosystem (only if not explicit)
+
+Look in the project root for the first marker file that exists, in this order:
+
+| File | Ecosystem |
+|---|---|
+| `package.json` | `npm` |
+| `pubspec.yaml` | `pub` |
+| `pyproject.toml` or `requirements.txt` | `pypi` |
+| `go.mod` | `go` |
+| `Cargo.toml` | `crates` |
+| `mix.exs` | `hex` |
+
+If none match, default to `npm`. The user can always override by using an explicit prefix.
+
+## Step 3 — Look up the ASK Registry
+
+Fetch the registry entry via WebFetch:
+
+```
+https://ask-registry.pages.dev/api/registry/<ecosystem>/<name>
+```
+
+If it returns 200 with at least one strategy, pick the **highest-priority** strategy using
+this stable order (lower number wins; ties keep registry order):
+
+| source | priority | rationale |
+|---|---|---|
+| `github` | 0 | Highest signal-to-noise — eval results show best accuracy at lowest cost |
+| `npm` | 1 | Reliable, version-pinned, but may miss prose docs |
+| `web` | 2 | Crawled HTML; expensive and noisier |
+| `llms-txt` | 3 | Last resort — eval scored below baseline on real tasks |
+
+Move on to Step 4 with the chosen strategy. Skip Step 3a entirely.
+
+## Step 3a — Fallback when the registry has no entry
+
+A 404 / empty strategies list does not mean we give up. Most popular packages can be
+located via their package manager's own metadata. Try in order, stopping at the first hit:
+
+- **npm**: `bun pm view <name> repository.url homepage` (or `npm view`). Extract a
+  GitHub repo from `repository.url` and fall back to `github` source. If no repo, fetch
+  the npm tarball and look for a `docs/` or `README.md`.
+- **pypi**: `https://pypi.org/pypi/<name>/json` → look in `info.project_urls` for any
+  GitHub or "Source" URL → use `github` source.
+- **go**: if the module path itself is `github.com/<owner>/<repo>/...`, use that directly
+  with `github` source. Otherwise check `https://pkg.go.dev/<name>` for a "Repository" link.
+- **crates**: `https://crates.io/api/v1/crates/<name>` → `crate.repository` → `github`.
+- **hex**: `https://hex.pm/api/packages/<name>` → `meta.links.GitHub` (or any `github.com` URL).
+- **pub**: `https://pub.dev/api/packages/<name>` → `latest.pubspec.repository` (or `homepage`).
+- **llms.txt sniff**: if the package has a homepage, HEAD `<homepage>/llms.txt` and
+  `<homepage>/llms-full.txt`. If either responds 200, use `llms-txt` source on it.
+- **Give up cleanly**: if nothing works, stop and ask the user for an explicit
+  `source` + `repo`/`url`. **Do not invent a repo URL.** Wrong docs are worse than no docs.
+
+## Step 4 — Fetch the docs
+
+Each source produces a list of `{ path, content }` files plus a `resolvedVersion`.
+
+### github
+1. Build the archive URL:
+   - tag: `https://github.com/<repo>/archive/refs/tags/<tag>.tar.gz`
+   - branch: `https://github.com/<repo>/archive/refs/heads/<branch>.tar.gz`
+2. `curl -L -o /tmp/<name>.tar.gz <url>` then extract into a temp dir.
+3. From the extracted root, look for the first existing directory in:
+   `docs/`, `doc/`, `documentation/`, `guide/`, `guides/` (or honor an explicit `docsPath`).
+4. Recursively collect every file with extension `.md`, `.mdx`, `.txt`, `.rst`. Preserve
+   the relative path under the docs dir.
+5. `resolvedVersion` is the tag (strip a leading `v`) or the branch's commit sha — when
+   you only have the branch, use the branch name.
+
+### npm
+1. `bun pm view <name>@<version> dist.tarball version` (or the equivalent `npm view`).
+   Use the printed `dist.tarball` URL and the printed exact `version` as `resolvedVersion`.
+2. Download with `curl -L`, extract.
+3. Same docs-folder discovery as github (`docs/`, `doc/`, ...).
+4. Same extension filter (`.md`, `.mdx`, `.txt`, `.rst`).
+
+### web
+1. Start from the user-supplied `url`(s). Use WebFetch to retrieve each page as Markdown.
+2. Follow same-origin links up to `maxDepth` (default `1`). Respect `pathPrefix` if given.
+3. Skip assets (`.png`, `.jpg`, `.css`, `.js`, `.woff*`) and auth-ish paths
+   (`/api`, `/auth`, `/login`, `/signup`, `/search`).
+4. Derive each output filename from the URL path (`/docs/guide.html` → `docs/guide.md`).
+5. `resolvedVersion` falls back to today's date (`YYYY-MM-DD`) when the source has no
+   version concept.
+
+### llms-txt
+1. WebFetch the single URL.
+2. Save as one file; derive the filename from the URL path, ensuring a `.md` or `.txt`
+   extension.
+3. `resolvedVersion`: today's date if not otherwise known.
+
+If a fetch yields **zero files**, stop and report. Don't write an empty docs directory.
+
+## Step 5 — Save to `.ask/docs/`
+
+Target directory: `.ask/docs/<name>@<resolvedVersion>/`
+
+1. If the directory already exists, **delete it first** so a stale partial fetch can't
+   linger. This is the same behavior as the CLI's `storage.ts`.
+2. Create the directory and write each file, preserving subdirectories.
+3. Generate `INDEX.md` listing every file as a relative Markdown link, sorted by path.
+   Example:
+   ```markdown
+   # <name> v<resolvedVersion> — Documentation Index
+
+   - [README.md](./README.md)
+   - [guide/getting-started.md](./guide/getting-started.md)
+   ```
+
+## Step 6 — Update `.ask/config.json`
+
+Read the file (create `{ "docs": [] }` if missing). The `docs` array stores entries that
+`sync-docs` later replays. Each entry is the `SourceConfig` you used in Step 4:
+
+```json
+{
+  "docs": [
+    {
+      "name": "zod",
+      "version": "3.22.4",
+      "source": "github",
+      "repo": "colinhacks/zod",
+      "tag": "v3.22.4",
+      "docsPath": "docs"
+    }
+  ]
+}
+```
+
+If an entry with the same `name` already exists, **replace it** (not append). Match on
+name only — version changes should overwrite, not duplicate. Write the file back as
+pretty-printed JSON (2-space indent) with a trailing newline.
+
+## Step 6.5 — Record the fetch in `.ask/ask.lock`
+
+`config.json` is **intent** ("track this library"); `ask.lock` is **fact** ("here is
+exactly what we last downloaded"). The lock is what makes drift detection in `sync-docs`
+reliable, especially when the user tracks `latest` instead of a pinned version.
+
+Read `.ask/ask.lock` (create with `{ "lockfileVersion": 1, "entries": {} }` if missing),
+then upsert the entry for this library by name:
+
+```json
+{
+  "lockfileVersion": 1,
+  "generatedAt": "<ISO-8601 timestamp>",
+  "entries": {
+    "<name>": {
+      "version": "<resolvedVersion>",
+      "source": "<github|npm|web|llms-txt>",
+      "repo": "<owner/repo>",          // github only
+      "ref": "<tag-or-branch>",         // github only
+      "commit": "<full-sha>",           // github only, when known
+      "tarball": "<url>",               // npm only
+      "integrity": "<sha512-...>",      // npm only, from `dist.integrity`
+      "url": "<url>",                   // web/llms-txt only
+      "fetchedAt": "<ISO-8601 timestamp>",
+      "fileCount": <number>,
+      "contentHash": "sha256-<hex>"
+    }
+  }
+}
+```
+
+`contentHash` is computed by sorting the saved files by relative path, concatenating
+`<relpath>\0<bytes>\0` for each, and taking SHA-256 of the whole stream. This makes any
+file addition, removal, rename, or content change visible without listing the tree.
+
+For `github`, capture the commit sha by checking the `Location` header of
+`https://github.com/<repo>/archive/refs/{tags|heads}/<ref>.tar.gz` (it redirects to a
+URL containing the sha) or by hitting
+`https://api.github.com/repos/<repo>/commits/<ref>`. If neither works, omit `commit`
+rather than guessing.
+
+For `npm`, pull `dist.integrity` from the same `bun pm view` / `npm view` call you
+already made in Step 4.
+
+Update `generatedAt` at the top of the file. Write back as pretty JSON.
+
+**Lock is committed.** It plays the same role for ASK that `bun.lock` plays for bun:
+the source of truth for "what's actually installed".
+
+## Step 7 — Update `AGENTS.md`
+
+`AGENTS.md` is the file AI agents read first. ASK manages a single auto-generated block
+inside it, fenced by HTML comment markers:
+
+```
+<!-- BEGIN:ask-docs-auto-generated -->
+...managed content...
+<!-- END:ask-docs-auto-generated -->
+```
+
+**Read `AGENTS.md` first** (if it exists) and decide:
+
+- **File missing**: create it with just the marker block.
+- **Markers present**: replace everything **between** the markers, leaving the markers
+  themselves and all surrounding content untouched.
+- **File exists, no markers**: append the marker block at the end with one blank line
+  before it.
+
+The block content lists **every entry currently in `.ask/config.json`** (not just the
+one you added — this keeps the block coherent after multiple `add-docs` calls). Use this
+template:
+
+```markdown
+<!-- BEGIN:ask-docs-auto-generated -->
+# Documentation References
+
+The libraries in this project may have APIs and patterns that differ from your training
+data. **Always read the relevant documentation before writing code.**
+
+## <name> v<version>
+
+> **WARNING:** This version may differ from your training data.
+> Read the docs in `.ask/docs/<name>@<version>/` before writing any <name>-related code.
+> Heed deprecation notices and breaking changes.
+
+- **Version**: `<version>` — use `"^<major>"` in package.json (NOT older major versions)
+- Documentation: `.ask/docs/<name>@<version>/`
+- Index: `.ask/docs/<name>@<version>/INDEX.md`
+
+[... repeat per library, in the order they appear in config.json ...]
+<!-- END:ask-docs-auto-generated -->
+```
+
+The "use `^<major>`" line only makes sense for npm — omit it for non-npm ecosystems.
+
+**Critical guardrail**: never touch content outside the markers. Users keep their own
+notes there.
+
+## Step 8 — Ensure `CLAUDE.md` references `AGENTS.md`
+
+Read `CLAUDE.md` (create it if missing). If it does not already contain a line that is
+exactly `@AGENTS.md` (or starts with `@AGENTS.md` followed by whitespace), append one.
+Do not write anything else into `CLAUDE.md` — the canonical content lives in `AGENTS.md`.
+
+---
+
+## Guardrails (apply to every step)
+
+- **Always Read before Write.** Inspect existing `.ask/config.json`, `AGENTS.md`,
+  `CLAUDE.md`, and the target docs directory before changing them.
+- **Never invent versions.** If a source returns no version, propagate that and either
+  use `latest` or the date stamp. Don't guess.
+- **Never invent repo URLs.** If Step 3a fails to find a real source, stop and ask.
+- **Marker block is sacred.** Content outside `<!-- BEGIN:... -->` / `<!-- END:... -->`
+  is owned by the user.
+- **Honor explicit user overrides.** If the user pins `--source github --repo foo/bar`,
+  skip the registry and the fallback chain entirely.
+- **Failure must be loud.** Stop and report instead of writing partial state.
+
+## Verification checklist
+
+After completing the pipeline for a library, confirm:
+
+- [ ] `.ask/docs/<name>@<version>/` exists and contains at least one doc file
+- [ ] `.ask/docs/<name>@<version>/INDEX.md` exists and links every file
+- [ ] `.ask/config.json` has exactly one entry for `<name>` with the new version
+- [ ] `.ask/ask.lock` `entries.<name>` matches the version, source, fileCount, and contentHash you just wrote
+- [ ] `AGENTS.md` contains the marker block, and the block lists `<name> v<version>`
+- [ ] `CLAUDE.md` contains a `@AGENTS.md` line
+- [ ] Nothing outside the marker block in `AGENTS.md` was modified
+
+If any item fails, fix it before reporting success.

--- a/skills/setup-docs/SKILL.md
+++ b/skills/setup-docs/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: setup-docs
+description: >
+  Bootstrap documentation for an entire project's dependencies in one shot. Reads the
+  project's manifest and lockfile, derives the full dependency list with resolved
+  versions, asks the user to confirm the targets, then runs the `add-docs` pipeline for
+  each one and rebuilds the `AGENTS.md` auto-generated block in a single pass. Use this
+  skill when the user is initializing ASK on a project for the first time, has just
+  cloned a repo and wants every dependency's docs available, or asks something like
+  "ASK 셋업해줘", "이 프로젝트 의존성 문서 다 받아줘", "set up ask for this repo",
+  "bootstrap docs for all deps", "initialize agents.md from package.json". Trigger on:
+  "셋업", "setup", "bootstrap", "초기화", "initialize", "all dependencies", "전체 의존성",
+  combined with any mention of docs, AGENTS.md, or ASK.
+---
+
+# setup-docs — Bootstrap Docs for Every Dependency
+
+One-shot project initialization. Use this when the user wants documentation for **every**
+dependency, not just one specific library.
+
+For a single library, use `add-docs` instead.
+For refreshing already-tracked libraries after upgrades, use `sync-docs`.
+
+## When to use this skill
+
+- New ASK adoption: the user just installed ASK and has nothing in `.ask/docs/` yet.
+- Fresh clone: the user wants to populate `AGENTS.md` from scratch based on the project's
+  dependencies.
+- Major reorganization: the user explicitly wants to rebuild the full doc set.
+
+## Pipeline
+
+```
+parse manifest + lockfile → derive (name, version) list → confirm with user
+  → for each: run add-docs steps 1–6.5 (writes config + ask.lock per entry)
+  → final pass: rebuild AGENTS.md block once → ensure CLAUDE.md @AGENTS.md
+```
+
+The key difference from running `add-docs` in a loop: **Step 7 (AGENTS.md regeneration)
+runs only once at the very end** so the file isn't rewritten N times.
+
+## Step 1 — Parse the manifest and lockfile
+
+Detect the ecosystem the same way `add-docs` Step 2 does, then parse the relevant files.
+Always prefer the **lockfile** for the resolved version; fall back to the manifest's
+declared range only when no lockfile exists.
+
+| Ecosystem | Manifest | Lockfile (preferred for version) |
+|---|---|---|
+| npm | `package.json` (`dependencies` + `devDependencies` + `peerDependencies`) | `bun.lock`, `bun.lockb`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock` |
+| pypi | `pyproject.toml` (`[project.dependencies]` or `[tool.poetry.dependencies]`) or `requirements.txt` | `poetry.lock`, `uv.lock`, pinned `requirements.txt` |
+| go | `go.mod` (`require` block) | `go.sum` (versions are already in `go.mod`) |
+| crates | `Cargo.toml` (`[dependencies]`) | `Cargo.lock` |
+| pub | `pubspec.yaml` (`dependencies`) | `pubspec.lock` |
+| hex | `mix.exs` (`deps/0`) | `mix.lock` |
+
+For each dependency, produce a `(ecosystem, name, version)` triple. If the lockfile gives
+a precise version (e.g. `3.22.4`), use that. If only a range is available (e.g. `^3.22`),
+pass the range to `add-docs` and let the source resolve it.
+
+**Skip**: workspace-internal packages, `link:`/`file:`/`workspace:` deps, and anything
+that resolves to a path. These don't have docs to download.
+
+## Step 2 — Show the plan and confirm
+
+Print the derived list to the user as a table or bullet list, grouped by ecosystem if
+mixed. Then **stop and ask for confirmation** before fetching anything. Example:
+
+```
+About to fetch docs for 14 dependencies:
+
+npm:
+  - zod@3.22.4
+  - hono@4.6.2
+  - drizzle-orm@0.36.0
+  ...
+
+Proceed? (yes / select subset / cancel)
+```
+
+If the list is large (>30 entries), warn the user about wall-clock time and offer to
+filter (e.g. only `dependencies`, skip `devDependencies`).
+
+## Step 3 — Run `add-docs` Steps 1–6.5 for each entry
+
+For each `(ecosystem, name, version)`:
+
+1. Follow `add-docs` Steps 1–6.5 exactly (parse, registry lookup, fallback, fetch, save,
+   update `.ask/config.json`, record into `.ask/ask.lock`).
+2. **Skip Step 7** for now — the AGENTS.md regeneration is deferred.
+3. On failure, **do not abort the whole batch**. Record the error and continue. Examples
+   of survivable failures: registry miss + no fallback, source returned zero files,
+   network timeout.
+4. Track results in two buckets: `succeeded[]` and `failed[{name, reason}]`.
+
+You may run fetches in parallel (up to ~4 at a time) when the source allows it
+(`github` and `npm` archive downloads parallelize cleanly; `web` crawls should stay
+serial to be polite to upstream servers).
+
+## Step 4 — Regenerate AGENTS.md once
+
+After the loop, run `add-docs` Step 7 a single time. Because Step 6 already populated
+`.ask/config.json` with every successful entry, the regenerated marker block will
+list them all in one shot. Then run Step 8 to ensure `CLAUDE.md` references `AGENTS.md`.
+
+## Step 5 — Report
+
+Print a summary:
+
+```
+Fetched docs for 12 of 14 dependencies.
+
+✓ Succeeded: zod, hono, drizzle-orm, ...
+✗ Failed:
+  - some-private-pkg: registry miss, no GitHub repo in npm metadata
+  - obscure-lib: no docs/ directory found in tarball
+
+To retry a failure manually, run add-docs with explicit --source.
+```
+
+The failures are recoverable with manual hints, so keep the message actionable.
+
+## Guardrails
+
+- **Always confirm before fetching.** Mass downloads against many upstream servers
+  deserve a human checkpoint.
+- **Partial success is fine.** Don't roll back successful fetches because one failed.
+- **Idempotency.** Re-running `setup-docs` on a project that already has entries should
+  replace them in place (Step 6 already does this) — not duplicate.
+- All `add-docs` guardrails apply transitively: read before write, never invent versions
+  or repos, marker block is sacred.

--- a/skills/sync-docs/SKILL.md
+++ b/skills/sync-docs/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: sync-docs
+description: >
+  Detect drift between the project's installed dependency versions and the docs already
+  saved under `.ask/docs/`, then re-fetch only what changed. Reads `.ask/config.json`,
+  compares each tracked entry to the current resolved version in the project's lockfile,
+  and runs the `add-docs` pipeline for any version that moved. Also prunes entries for
+  dependencies that were removed and reports any new dependencies that have no docs yet.
+  MUST use this skill whenever the user mentions upgrading dependencies, after running
+  `bun add` / `npm install` / `pnpm up` / `cargo update` / etc., when the lockfile
+  changed, or when the user asks "의존성 업데이트했어 문서도 갱신해줘", "sync docs",
+  "refresh docs after upgrade", "버전 올렸어", "lockfile 바뀌었어", "ASK 동기화".
+  Trigger on: "sync", "동기화", "drift", "refresh docs", "after upgrade", "업그레이드 후",
+  "버전 변경", "lockfile changed", combined with any mention of docs or ASK.
+---
+
+# sync-docs — Detect Drift and Re-fetch Changed Docs
+
+Keeps `.ask/docs/` and `AGENTS.md` aligned with the project's actual installed
+dependency versions. Run this whenever the lockfile moves.
+
+For first-time setup, use `setup-docs`.
+For adding a brand-new library that isn't tracked yet, use `add-docs`.
+
+## When to use this skill
+
+- The user just ran `bun add`, `bun update`, `npm install`, `pnpm up`, `cargo update`,
+  `go get -u`, etc.
+- The user explicitly asks to refresh, sync, or check drift.
+- A code review notices `AGENTS.md` references stale versions.
+- Periodic maintenance ("clean up old docs").
+
+## Pipeline
+
+```
+read .ask/config.json + .ask/ask.lock → parse current manifest/lockfile → classify each entry
+  → for each "changed": run add-docs steps 1–6.5 (and delete the old version dir)
+  → for each "removed": prune dir + remove from config + remove from lock (with confirmation)
+  → for each "new in manifest, missing from config": report only, recommend setup-docs
+  → final pass: rebuild AGENTS.md block once → ensure CLAUDE.md @AGENTS.md
+  → summarize
+```
+
+## Step 1 — Load tracked entries
+
+Read `.ask/config.json`. If it doesn't exist or has an empty `docs[]`, tell the user
+there's nothing to sync and recommend `setup-docs`. Stop.
+
+## Step 2 — Read current installed versions
+
+Parse the manifest and lockfile exactly like `setup-docs` Step 1. Build a map of
+`name → currentResolvedVersion` for the ecosystem the project uses. Prefer the lockfile.
+
+## Step 3 — Classify every tracked entry
+
+For each entry in `.ask/config.json`'s `docs[]`, compute one of these states:
+
+| State | Condition | Action |
+|---|---|---|
+| **unchanged** | Tracked version === current version | Skip |
+| **drifted** | Tracked version ≠ current version, name still in manifest | Re-fetch |
+| **removed** | Name no longer in manifest at all | Prune (with confirmation) |
+| **untracked** | Name **is** in manifest but **not** in `.ask/config.json` | Report only |
+
+**Comparison source**: prefer `.ask/ask.lock` `entries.<name>.version` (and `.commit`
+for github sources) over `config.json.version`. The lock records what was *actually*
+fetched last time, while `config.json.version` may be a moving target like `latest`. If
+the lock has no entry for a tracked name, treat it as **drifted** (forces a re-fetch
+to populate the lock).
+
+For github entries, also compare `lock.commit` against the current head of the same
+ref. If the version string is unchanged but the commit moved (common when tracking
+`main`), that still counts as drift.
+
+Group the results by state and **show the user the plan before doing anything destructive**:
+
+```
+Drift detected:
+  ⟳  zod          3.22.4 → 3.23.8     (will re-fetch)
+  ⟳  hono         4.6.2  → 4.6.5      (will re-fetch)
+
+Removed from project (will prune docs after confirmation):
+  ✗  old-lib      1.0.0
+
+New dependencies without docs (run `setup-docs` or `add-docs` to fetch):
+  +  brand-new-pkg @ 0.4.1
+
+Unchanged (skipping): 11 entries
+
+Proceed with re-fetch and prune?
+```
+
+## Step 4 — Re-fetch drifted entries
+
+For each `drifted` entry:
+
+1. Run `add-docs` Steps 1–6 with the new version. The pipeline will overwrite the
+   `.ask/config.json` entry in place (Step 6 already replaces by name).
+2. **After** the new version is on disk, delete the **old** directory:
+   `rm -rf .ask/docs/<name>@<oldVersion>/`. Do this only after the new fetch
+   succeeds so a failed fetch can't leave the project with no docs at all.
+3. On failure, leave the old directory intact, record the error, and continue.
+
+Parallelism rules from `setup-docs` Step 3 apply: github/npm in parallel (≤4), web serial.
+
+## Step 5 — Prune removed entries
+
+For each `removed` entry, after the user has confirmed:
+
+1. Delete `.ask/docs/<name>@<version>/` recursively.
+2. Remove the entry from `.ask/config.json`'s `docs[]`.
+
+If the user declined to prune, skip — do not silently keep stale data and do not
+silently delete it either.
+
+## Step 6 — Report untracked dependencies
+
+For each `untracked` entry, **just list it**. Do not auto-fetch — the user might have
+a reason that dependency isn't tracked (e.g. it's a build tool with no useful docs).
+Recommend `add-docs <name>` or `setup-docs` if they want full coverage.
+
+## Step 7 — Rebuild AGENTS.md and CLAUDE.md
+
+Run `add-docs` Step 7 once at the end so the marker block reflects the post-sync state
+of `.ask/config.json`. Then `add-docs` Step 8 to ensure the `@AGENTS.md` reference.
+
+If the sync resulted in **zero changes** to `.ask/config.json`, you can still re-run
+Step 7 — it'll be a no-op rewrite — or skip it. Skipping is fine and avoids touching
+the file's mtime.
+
+## Step 8 — Summarize
+
+Print exactly what changed:
+
+```
+Synced 13 tracked entries.
+
+Re-fetched (2):
+  ⟳ zod  3.22.4 → 3.23.8
+  ⟳ hono 4.6.2  → 4.6.5
+
+Pruned (1):
+  ✗ old-lib 1.0.0
+
+Untracked dependencies (3) — run add-docs to fetch:
+  + brand-new-pkg, another-new-thing, yet-another
+
+AGENTS.md updated.
+```
+
+## Guardrails
+
+- **Never delete the old version directory before the new fetch succeeds.** Order
+  matters — prefer brief disk waste over a window with no docs.
+- **Confirm before pruning.** Removed-from-manifest is a strong signal but not
+  irreversible from the user's perspective; ask first.
+- **Don't auto-fetch untracked deps.** That's `setup-docs` / `add-docs`'s job and
+  the user should opt in.
+- All `add-docs` guardrails apply transitively.
+
+## Future automation note
+
+When ASK ships as a Claude Code plugin, this skill is the natural target for a
+`PostToolUse` hook on lockfile edits — the hook can invoke `sync-docs` automatically
+after `bun.lock` / `package-lock.json` / etc. change. That's outside the scope of this
+skill itself; it just needs to be runnable on demand.


### PR DESCRIPTION
Add three Claude Code skills under skills/ that mirror the ask CLI's docs workflow without requiring the binary:

- add-docs: single-library fetch with registry lookup, ecosystem fallback chain (npm/pypi/go/crates/hex/pub → github → llms.txt sniff), and AGENTS.md marker block management
- setup-docs: batch bootstrap from manifest+lockfile with user confirmation and one-shot AGENTS.md regeneration
- sync-docs: drift detection comparing .ask/ask.lock against current lockfile, with re-fetch and prune flows

Skills target the .ask/ workspace (.ask/docs/, .ask/config.json, .ask/ask.lock) in preparation for shipping ask as a standalone Claude Code plugin.