### PR TITLE
fix(ci): pin release-please-action to v4.4.0 with valid SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       release_created: ${{ steps.release.outputs['packages/cli--release_created'] }}
       tag_name: ${{ steps.release.outputs['packages/cli--tag_name'] }}
     steps:
-      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d6f8e03db635a # v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary

- The previous `googleapis/release-please-action` SHA (`a02a34c`) does not exist in the repository, causing the workflow to fail
- Pins to the correct SHA (`16a9c90`) for the `v4.4.0` release tag

## Changes

- `.github/workflows/release.yml`: Update action reference from invalid SHA with `# v4` comment to the verified SHA for `v4.4.0`

## Test Plan

- [ ] Verify the release workflow runs successfully on next trigger
- [ ] Confirm `googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38` resolves correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release workflow by pinning `googleapis/release-please-action` to the verified v4.4.0 commit. Replaces the invalid ref with `16a9c90856f42705d54a6fda1823352bdc62cf38`.

<sup>Written for commit e0efbbc087e4d9519184f43d7f4416583a467a8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

