### PR TITLE
ci: build CLI via turbo to resolve workspace deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build CLI
-        run: bun run --cwd packages/cli build
+        run: bun run build --filter=@pleaseai/ask
 
       - name: Pack with bun (resolve workspace deps)
         working-directory: packages/cli


### PR DESCRIPTION
## Summary
`tsc` in `packages/cli` fails with `TS2307: Cannot find module '@pleaseai/registry-schema'` during the release workflow.

## Root Cause
The release workflow's Build CLI step ran `bun run --cwd packages/cli build`, which only builds the CLI. The workspace dependency `@pleaseai/registry-schema` has `exports` pointing to `./dist/*`, but its `dist/` is never produced — so `tsc` in the CLI cannot resolve the type declarations.

## Changes
- Switch release workflow to `bun run build --filter=@pleaseai/ask`, delegating to root `turbo build` which respects the workspace dependency graph and builds `@pleaseai/registry-schema` before the CLI.

## Test Plan
- [ ] Release workflow passes the Build CLI step on merge to main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the CLI via Turbo in the release workflow to respect workspace deps and prevent TS2307 errors. This ensures `@pleaseai/registry-schema` is built before the CLI.

- **Bug Fixes**
  - Replace `bun run --cwd packages/cli build` with `bun run build --filter=@pleaseai/ask` so `@pleaseai/registry-schema` produces `dist/` before `@pleaseai/ask` builds.

<sup>Written for commit 49c8f7a3512790733c8897d120ffe9d90b0e7f0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

