### PR TITLE
docs(claude): add please:knowledge navigation block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,3 +122,23 @@ Nuxt + Nuxt Content v3 + Nuxt UI. Registry entries are GitHub repo-based: `conte
 - Use `consola` for all user-facing output, never raw `console.log`
 - Regex patterns used in loops must be defined at module scope (`e18e/prefer-static-regex`)
 - Import `process` from `node:process` explicitly (`node/prefer-global/process`)
+
+<!-- please:knowledge v1 -->
+## Project Knowledge
+
+Consult these files for project context before exploring the codebase.
+For full file listing with workspace artifacts, use `Skill("please:project-knowledge")`.
+
+### Project Documents
+- `ARCHITECTURE.md` — Codebase structure, module boundaries, architectural invariants
+
+### Domain Knowledge (.please/docs/knowledge/)
+- `product.md` — Product vision, goals, target users
+- `product-guidelines.md` — Branding, UX principles, design system
+- `tech-stack.md` — Technology choices with rationale
+- `workflow.md` — Task lifecycle, TDD, quality gates, dev commands
+- `gotchas.md` — Known project pitfalls and workarounds
+
+### Decision Records
+- `.please/docs/decisions/` — Architecture Decision Records (ADR)
+<!-- /please:knowledge -->


### PR DESCRIPTION
## Summary

- Adds a `<!-- please:knowledge v1 -->` block to `CLAUDE.md` that surfaces canonical project context files for agents before codebase exploration
- Points to `ARCHITECTURE.md`, domain knowledge docs under `.please/docs/knowledge/`, and ADRs under `.please/docs/decisions/`

## Test Plan

- [ ] Verify the block renders correctly in the GitHub CLAUDE.md preview
- [ ] Confirm `Skill("please:project-knowledge")` reference is accurate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `<!-- please:knowledge v1 -->` block in `CLAUDE.md` to surface canonical project context before code exploration. It indexes `ARCHITECTURE.md`, domain docs in `.please/docs/knowledge/`, ADRs in `.please/docs/decisions/`, and points to `Skill("please:project-knowledge")` for a full listing.

<sup>Written for commit 937f77ba2726961b647be1a821067d935e15bda8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

