### PR TITLE
docs(cli): fix runDocs JSDoc stale store path

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -26,7 +26,7 @@ export interface RunDocsDeps {
  *   1. For npm-ecosystem specs only: `node_modules/<pkg>/` if installed.
  *      Always emits the package root as the first line of that source,
  *      followed by any subdirectory whose basename matches `/doc/i`.
- *   2. The cached source tree (`~/.ask/github/checkouts/<o>__<r>/<ref>/`).
+ *   2. The cached source tree (`<askHome>/github/<host>/<owner>/<repo>/<ref>/`).
  *      Always emits the checkout root, followed by any `/doc/i` subdirs.
  *
  * The agent decides which path is the "real" docs by reading the


### PR DESCRIPTION
## Summary
- `runDocs` JSDoc in `packages/cli/src/commands/docs.ts` referenced the
  legacy store layout `~/.ask/github/checkouts/<o>__<r>/<ref>/` which was
  replaced by the PM-unified layout
  `<askHome>/github/<host>/<owner>/<repo>/<ref>/` (see `githubStorePath`
  in `packages/cli/src/store/index.ts` and the
  `github-store-pm-unified-20260411` track).
- Comment-only change — runtime behaviour unchanged.

## Test plan
- [x] Documentation/comment only — no runtime change.
- [x] New path verified against `githubStorePath` (store/index.ts) and
      `checkoutDir` assignment in `ensure-checkout.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `runDocs` JSDoc in `packages/cli/src/commands/docs.ts` to use the PM‑unified store path `<askHome>/github/<host>/<owner>/<repo>/<ref>/` instead of the legacy `~/.ask/github/checkouts/<o>__<r>/<ref>/`. Comment-only change with no runtime impact.

<sup>Written for commit 0dce66f4034c3b113495cc825238d5b202f74360. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

