### PR TITLE
fix(docs,skills): emit only doc-like subdirs; fixed-path skills check

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -20,19 +20,22 @@ export interface RunDocsDeps {
 
 /**
  * Implementation of `ask docs <spec>`. Resolves the spec via the
- * shared `ensureCheckout` helper, then walks two locations and prints
- * every doc-like path found, one per line:
+ * shared `ensureCheckout` helper, then prints documentation candidate
+ * paths from two locations (one per line):
  *
  *   1. For npm-ecosystem specs only: `node_modules/<pkg>/` if installed.
- *      Always emits the package root as the first line of that source,
- *      followed by any subdirectory whose basename matches `/doc/i`.
  *   2. The cached source tree (`<askHome>/github/<host>/<owner>/<repo>/<ref>/`).
- *      Always emits the checkout root, followed by any `/doc/i` subdirs.
  *
- * The agent decides which path is the "real" docs by reading the
- * contents. Multi-line output is intentional — it lets `rg` and `fd`
- * search across multiple candidates simultaneously via shell
- * substitution.
+ * For each location, `findDocLikePaths` emits:
+ *   - `dist/docs` when it exists (publish-time convention, e.g. mastra).
+ *   - Any subdirectory whose basename matches `/doc/i` up to depth 4.
+ *   - The root itself as a fallback when nothing above matches
+ *     (README-only packages).
+ *
+ * Emitting only doc-like paths when they exist keeps shell substitution
+ * (`rg "x" $(ask docs <spec>)`) focused on documentation instead of
+ * dragging the entire source tree into the search. Callers that need
+ * the checkout root itself should use `ask src`.
  */
 export async function runDocs(options: RunDocsOptions, deps: RunDocsDeps = {}): Promise<void> {
   const ensureCheckout = deps.ensureCheckout ?? defaultEnsureCheckout

--- a/packages/cli/src/commands/find-doc-paths.ts
+++ b/packages/cli/src/commands/find-doc-paths.ts
@@ -19,29 +19,44 @@ const SKIP_DIRS = new Set([
 const MAX_DEPTH = 4
 
 /**
- * Walk `root` and return:
- *   - The root itself as the first element (always, even if empty/missing).
- *   - Every subdirectory whose basename matches `/doc/i`, up to depth 4.
+ * Walk `root` and return every subdirectory whose basename matches
+ * `/doc/i`, up to depth 4. When no such subdirectory exists, fall back
+ * to `[root]` so small projects whose docs live as a top-level
+ * `README.md` still produce a usable path.
  *
  * Skips `node_modules`, `.git`, `.next`, `.nuxt`, `dist`, `build`,
  * `coverage`, and any dotdir.
  *
- * Used by `ask docs` to surface candidate documentation paths from a
- * cached source tree (and from `node_modules/<pkg>/` for npm specs).
- * The caller — typically a coding agent — decides which path is the
- * "real" docs directory by reading the contents.
+ * Used by `ask docs` to surface documentation paths from a cached
+ * source tree (and from `node_modules/<pkg>/` for npm specs). Emitting
+ * only doc-like subdirs when they exist keeps shell substitution
+ * (`rg "x" $(ask docs <spec>)`) focused on docs instead of dragging
+ * the whole source tree into the search. Callers that need the
+ * checkout root itself should use `ask src`.
  *
- * Returns an empty array when `root` does not exist (no throw). This
- * matches the calling convention of `ask docs`, which may want to walk
- * a node_modules path that does not exist for the current project.
+ * Returns an empty array when `root` does not exist (no throw).
  */
 export function findDocLikePaths(root: string): string[] {
   if (!fs.existsSync(root)) {
     return []
   }
-  const results: string[] = [root]
-  walk(root, 0, results)
-  return results
+  const subdirs: string[] = []
+
+  // `dist/docs` is a common publish-time convention (e.g. mastra ships
+  // its docs there). The walker skips `dist/` wholesale to avoid build
+  // noise, so probe this path explicitly.
+  const distDocs = path.join(root, 'dist', 'docs')
+  try {
+    if (fs.statSync(distDocs).isDirectory()) {
+      subdirs.push(distDocs)
+    }
+  }
+  catch {
+    // missing or not a directory — ignore
+  }
+
+  walk(root, 0, subdirs)
+  return subdirs.length > 0 ? subdirs : [root]
 }
 
 function walk(currentDir: string, depth: number, out: string[]): void {

--- a/packages/cli/src/commands/skills/list.ts
+++ b/packages/cli/src/commands/skills/list.ts
@@ -3,7 +3,26 @@ import path from 'node:path'
 import process from 'node:process'
 import { defineCommand } from 'citty'
 import { ensureCheckout as defaultEnsureCheckout, NoCacheError } from '../ensure-checkout.js'
-import { findSkillLikePaths } from '../find-skill-paths.js'
+
+/**
+ * Producer-side skills always live at a fixed `<root>/skills/` directory.
+ * No other layout is supported — callers that want to surface skills
+ * shipped by a library should look here.
+ */
+const SKILLS_BASENAME = 'skills'
+
+function skillsDirIfExists(root: string): string | undefined {
+  const candidate = path.join(root, SKILLS_BASENAME)
+  try {
+    if (fs.statSync(candidate).isDirectory()) {
+      return candidate
+    }
+  }
+  catch {
+    // missing or not a directory
+  }
+  return undefined
+}
 
 export interface RunSkillsListOptions {
   spec: string
@@ -20,12 +39,14 @@ export interface RunSkillsListDeps {
 
 /**
  * Implementation of `ask skills [list] <spec>`. Resolves the spec via the
- * shared `ensureCheckout` helper, then prints every candidate skills
- * directory found under `node_modules/<pkg>/` (for npm specs that are
- * locally installed) and under the cached checkout tree.
+ * shared `ensureCheckout` helper, then prints the producer-side skills
+ * directory (always `<root>/skills/`) for each available source:
  *
- * Output format mirrors `ask docs`: one absolute path per line. The agent
- * decides which path is the "real" producer-side skills directory.
+ *   - `node_modules/<pkg>/skills/` when the npm package is installed.
+ *   - `<checkoutDir>/skills/` from the cached source tree.
+ *
+ * Exits 1 with a helpful message when neither exists. Unlike `ask docs`,
+ * skills have a fixed layout — no walking, no fallback to the repo root.
  */
 export async function runSkillsList(
   options: RunSkillsListOptions,
@@ -56,16 +77,26 @@ export async function runSkillsList(
     return
   }
 
+  const found: string[] = []
   if (result.npmPackageName) {
     const nmPath = path.join(options.projectDir, 'node_modules', result.npmPackageName)
-    if (fs.existsSync(nmPath)) {
-      for (const p of findSkillLikePaths(nmPath)) {
-        log(p)
-      }
+    const nmSkills = skillsDirIfExists(nmPath)
+    if (nmSkills) {
+      found.push(nmSkills)
     }
   }
+  const checkoutSkills = skillsDirIfExists(result.checkoutDir)
+  if (checkoutSkills) {
+    found.push(checkoutSkills)
+  }
 
-  for (const p of findSkillLikePaths(result.checkoutDir)) {
+  if (found.length === 0) {
+    error(`no skills/ directory found for ${options.spec} — try 'ask src ${options.spec}' for the checkout root`)
+    exit(1)
+    return
+  }
+
+  for (const p of found) {
     log(p)
   }
 }

--- a/packages/cli/test/commands/docs.test.ts
+++ b/packages/cli/test/commands/docs.test.ts
@@ -39,7 +39,7 @@ afterEach(() => {
 })
 
 describe('runDocs', () => {
-  it('prints checkout root and any /doc/i subdirs from the source tree', async () => {
+  it('prints only /doc/i subdirs (not the checkout root) when docs exist', async () => {
     fs.mkdirSync(path.join(checkoutDir, 'docs'), { recursive: true })
     const { io, deps } = makeIo()
     const ensureCheckout = mock(async () => ({
@@ -57,12 +57,35 @@ describe('runDocs', () => {
       { ensureCheckout, ...deps },
     )
 
-    expect(io.stdout).toContain(checkoutDir)
     expect(io.stdout).toContain(path.join(checkoutDir, 'docs'))
+    expect(io.stdout).not.toContain(checkoutDir)
     expect(io.exitCode).toBeNull()
   })
 
-  it('walks node_modules/<pkg>/ for npm specs', async () => {
+  it('emits dist/docs for packages that publish docs there (mastra convention)', async () => {
+    const distDocs = path.join(checkoutDir, 'dist', 'docs')
+    fs.mkdirSync(distDocs, { recursive: true })
+    const { io, deps } = makeIo()
+    const ensureCheckout = mock(async () => ({
+      parsed: {} as any,
+      owner: 'mastra-ai',
+      repo: 'mastra',
+      ref: 'v0.1.0',
+      resolvedVersion: '0.1.0',
+      checkoutDir,
+      npmPackageName: 'mastra',
+    }))
+
+    await runDocs(
+      { spec: 'mastra', projectDir },
+      { ensureCheckout, ...deps },
+    )
+
+    expect(io.stdout).toContain(distDocs)
+    expect(io.stdout).not.toContain(checkoutDir)
+  })
+
+  it('walks node_modules/<pkg>/ for npm specs and emits only /doc/i subdirs', async () => {
     const nm = path.join(projectDir, 'node_modules', 'react')
     fs.mkdirSync(path.join(nm, 'docs'), { recursive: true })
     const { io, deps } = makeIo()
@@ -81,8 +104,10 @@ describe('runDocs', () => {
       { ensureCheckout, ...deps },
     )
 
-    expect(io.stdout).toContain(nm)
     expect(io.stdout).toContain(path.join(nm, 'docs'))
+    expect(io.stdout).not.toContain(nm)
+    // checkoutDir has no docs → falls back to root
+    expect(io.stdout).toContain(checkoutDir)
   })
 
   it('does NOT walk node_modules for non-npm specs', async () => {

--- a/packages/cli/test/commands/ensure-checkout.integration.test.ts
+++ b/packages/cli/test/commands/ensure-checkout.integration.test.ts
@@ -145,8 +145,10 @@ describe('ensureCheckout ↔ GithubSource.fetch layout contract', () => {
     )
 
     const storeDir = githubStorePath(askHome, 'github.com', 'agentskills', 'agentskills', 'main')
-    expect(stdout).toContain(storeDir)
+    // findDocLikePaths now emits only the /doc/i subdirs when they exist,
+    // omitting the checkout root to keep shell substitution focused on docs.
     expect(stdout).toContain(path.join(storeDir, 'docs'))
+    expect(stdout).not.toContain(storeDir)
     expect(stderr).toEqual([])
     expect(exitCode).toBeNull()
   })

--- a/packages/cli/test/commands/find-doc-paths.test.ts
+++ b/packages/cli/test/commands/find-doc-paths.test.ts
@@ -26,15 +26,29 @@ describe('findDocLikePaths', () => {
     expect(findDocLikePaths(missing)).toEqual([])
   })
 
-  it('always returns the root as the first element', () => {
+  it('returns [root] as fallback when no doc-like subdirs exist', () => {
     const result = findDocLikePaths(root)
-    expect(result[0]).toBe(root)
+    expect(result).toEqual([root])
   })
 
-  it('matches a top-level "docs" directory', () => {
+  it('matches a top-level "docs" directory and omits root', () => {
     const docs = mkdir('docs')
     const result = findDocLikePaths(root)
     expect(result).toContain(docs)
+    expect(result).not.toContain(root)
+  })
+
+  it('emits dist/docs even though dist is in the skip set', () => {
+    const distDocs = mkdir('dist', 'docs')
+    const result = findDocLikePaths(root)
+    expect(result).toContain(distDocs)
+    expect(result).not.toContain(root)
+  })
+
+  it('does not emit dist itself when dist/docs is absent', () => {
+    mkdir('dist', 'lib')
+    const result = findDocLikePaths(root)
+    expect(result).toEqual([root])
   })
 
   it('matches case-insensitive — "Documentation" qualifies', () => {
@@ -61,14 +75,13 @@ describe('findDocLikePaths', () => {
     expect(result.some(p => p.includes('.git'))).toBe(false)
   })
 
-  it('skips .next, .nuxt, dist, build, coverage', () => {
+  it('skips .next, .nuxt, build, coverage (dist/docs is a special allow-listed case)', () => {
     mkdir('.next', 'docs')
     mkdir('.nuxt', 'docs')
-    mkdir('dist', 'docs')
     mkdir('build', 'docs')
     mkdir('coverage', 'docs')
     const result = findDocLikePaths(root)
-    for (const skip of ['.next', '.nuxt', 'dist', 'build', 'coverage']) {
+    for (const skip of ['.next', '.nuxt', 'build', 'coverage']) {
       expect(result.some(p => p.includes(`${path.sep}${skip}${path.sep}`))).toBe(false)
     }
   })

--- a/packages/cli/test/commands/skills-list.test.ts
+++ b/packages/cli/test/commands/skills-list.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 })
 
 describe('runSkillsList', () => {
-  it('prints checkout root and any /skill/i subdirs', async () => {
+  it('prints only the fixed <checkout>/skills path, never the checkout root', async () => {
     fs.mkdirSync(path.join(checkoutDir, 'skills'), { recursive: true })
     const { io, deps } = makeIo()
     const ensureCheckout = mock(async () => ({
@@ -52,11 +52,11 @@ describe('runSkillsList', () => {
 
     await runSkillsList({ spec: 'react@18.2.0', projectDir }, { ensureCheckout, ...deps })
 
-    expect(io.stdout).toContain(checkoutDir)
-    expect(io.stdout).toContain(path.join(checkoutDir, 'skills'))
+    expect(io.stdout).toEqual([path.join(checkoutDir, 'skills')])
+    expect(io.exitCode).toBeNull()
   })
 
-  it('walks node_modules/<pkg>/ when the package is installed locally', async () => {
+  it('prints <nm>/skills when the npm package is installed locally', async () => {
     const pkgDir = path.join(projectDir, 'node_modules', 'react', 'skills')
     fs.mkdirSync(pkgDir, { recursive: true })
     const { io, deps } = makeIo()
@@ -73,6 +73,26 @@ describe('runSkillsList', () => {
     await runSkillsList({ spec: 'react', projectDir }, { ensureCheckout, ...deps })
 
     expect(io.stdout).toContain(pkgDir)
+    expect(io.stdout).not.toContain(path.join(projectDir, 'node_modules', 'react'))
+  })
+
+  it('exits 1 when no skills/ directory exists anywhere', async () => {
+    const { io, deps } = makeIo()
+    const ensureCheckout = mock(async () => ({
+      parsed: {} as any,
+      owner: 'facebook',
+      repo: 'react',
+      ref: 'v18.2.0',
+      resolvedVersion: '18.2.0',
+      checkoutDir,
+      npmPackageName: 'react',
+    }))
+
+    await runSkillsList({ spec: 'react', projectDir }, { ensureCheckout, ...deps })
+
+    expect(io.stdout).toEqual([])
+    expect(io.exitCode).toBe(1)
+    expect(io.stderr.join('\n')).toContain('no skills/ directory found')
   })
 
   it('exits 1 with NoCacheError message when ensureCheckout throws it', async () => {


### PR DESCRIPTION
## Summary

- `ask docs <spec>` now emits **only doc-like subdirectories** instead of the checkout root plus matched subdirs, eliminating source-code noise when used in shell substitutions like `` rg "parse" $(ask docs zod) ``
- `ask skills <spec>` now uses a **fixed `<root>/skills/` path check** instead of a directory walker, with a clear exit-1 message pointing to `ask src` when no `skills/` dir exists
- Adds an explicit `dist/docs` probe in `find-doc-paths.ts` so packages like mastra (which ship docs under `dist/docs`, a path normally excluded by `SKIP_DIRS`) are handled correctly

## Problem

`$(ask docs zod)` previously emitted both the checkout root _and_ matched doc subdirs. When used as a shell argument (e.g. with `rg`, `grep`, `find`), this caused recursion through the entire source tree — `src/`, `packages/`, `tests/`, build artefacts — polluting search results with non-doc content. The same issue affected `ask skills`.

## Design

**`ask docs` (subdirs-only + root fallback):**
- Walk the checkout for doc-like directories (`/doc/i` pattern).
- Emit matched subdirs only.
- Fall back to checkout root _only_ when zero subdirs match (README-only packages that have no dedicated docs folder).
- Probe `dist/docs` explicitly before the glob walk, because `dist/` is in `SKIP_DIRS` and would otherwise be skipped — this is what makes mastra's `dist/docs` work.

**`ask skills` (fixed path, no walking):**
- Emit `<root>/skills/` if it exists (Claude Code producer-side convention).
- Exit 1 with a message (`"No skills/ directory found — use 'ask src' for the source root"`) when absent, so shell callers fail visibly rather than silently receiving an empty substitution.
- `ask src` (unchanged) remains the single-path output for source-tree substitution.

## Test Plan

- [ ] `bun run --cwd packages/cli test -- find-doc-paths` — all cases pass, including root-fallback and `dist/docs` probe
- [ ] `bun run --cwd packages/cli test -- docs.test` — expectations match subdirs-only output; mastra `dist/docs` fixture passes
- [ ] `bun run --cwd packages/cli test -- skills-list` — fixed-path single output; exit-1 case when no `skills/` exists
- [ ] `bun run --cwd packages/cli lint` — no lint errors
- [ ] Verify `rg "parse" $(ask docs zod)` returns only docs-scoped results (no src/ noise)
- [ ] Verify `ask skills <pkg-without-skills>` exits 1 and prints helpful message

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ask docs` emit only doc-like subdirectories (with `dist/docs` support) and make `ask skills` use a fixed `<root>/skills/` path with a clear failure when missing. This keeps shell substitutions precise and avoids searching source noise.

- **Bug Fixes**
  - `ask docs <spec>`: prints only doc-like subdirs; falls back to root only when none exist; explicitly includes `dist/docs`.
  - `ask skills <spec>`: returns only `<root>/skills/`; exits 1 with a helpful message when missing; removes the directory walker.

- **Migration**
  - If you need the repo root in scripts, use `ask src` instead of `ask docs`.
  - Handle exit code 1 for `ask skills` when no `skills/` directory exists.

<sup>Written for commit a6b95a4ed673a6623215c5d04eb7669d5ceedcc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

