### PR TITLE
docs(research): add research index and bun pm pack lockfile bug entry

### DIFF
--- a/.please/docs/research/README.md
+++ b/.please/docs/research/README.md
@@ -1,0 +1,11 @@
+# Research Index
+
+## Recent Entries
+
+| ID | Title | Date | Tags |
+|----|-------|------|------|
+| 001 | [bun pm pack workspace:* version resolution bug (stale bun.lock)](./md/001-bun-pm-pack-workspace-lockfile-version-bug.md) | 2026-04-13 | bun, workspace, lockfile, pack, publish, monorepo, bug |
+
+## Summary
+
+Total entries: 1

--- a/.please/docs/research/md/001-bun-pm-pack-workspace-lockfile-version-bug.md
+++ b/.please/docs/research/md/001-bun-pm-pack-workspace-lockfile-version-bug.md
@@ -1,0 +1,49 @@
+---
+id: "001"
+title: "bun pm pack workspace:* version resolution bug (stale bun.lock)"
+url: "https://github.com/oven-sh/bun/issues/20477"
+date: 2026-04-13
+summary: "bun pm pack reads workspace:* resolved versions from bun.lock instead of the workspace package's actual package.json, causing stale versions to be embedded in packed tarballs after a version bump."
+tags: [bun, workspace, lockfile, pack, publish, monorepo, bug]
+---
+
+# bun pm pack workspace:* version resolution bug (stale bun.lock)
+
+## Status
+
+**Open bug** — confirmed as of April 2026. No fix shipped.
+
+## Primary Issue
+
+[#20477 — `bun pm pack` replaces workspace packages with bun.lock version, not their package.json one](https://github.com/oven-sh/bun/issues/20477)
+
+Reported against Bun 1.2.16 on Darwin arm64. Exact scenario:
+
+1. Monorepo has package B depending on package A via `"A": "workspace:*"`.
+2. A's `package.json` version is bumped (e.g. `0.3.0` → `0.3.1`).
+3. `bun install` does NOT update the version entry for A in `bun.lock`.
+4. `bun pm pack` in B's directory resolves `workspace:*` to `0.3.0` (the stale lockfile value) instead of `0.3.1` (the current `package.json` value).
+
+The packed tarball therefore publishes the wrong resolved version for the workspace dependency.
+
+## Root Cause Issue
+
+[#18906 — bun.lock workspace versions no longer get updated after bumping workspace package.json version](https://github.com/oven-sh/bun/issues/18906)
+
+Since Bun 1.2.7, `bun install --lockfile-only` only updates workspace version entries in `bun.lock` when a dependency changes, not when the workspace package's own version field is bumped. This upstream staleness is what `bun pm pack` then exposes.
+
+## Related Issue
+
+[#18518 — `bun pm pack` is unable to handle bundled dependencies when using "workspace:*"](https://github.com/oven-sh/bun/issues/18518)
+
+A separate but related failure mode where `bun pm pack` cannot resolve workspace versions for bundled dependencies.
+
+## Known Workarounds
+
+1. **Run `bun update <package-name>`** after bumping a workspace package version — forces the lockfile entry to refresh before packing.
+2. **Delete `bun.lock` and re-run `bun install`** before `bun pm pack` — heavy-handed but reliable in CI.
+3. **Use `bun publish` directly** instead of `bun pm pack` if the workflow permits.
+
+## Impact on release-please Workflows
+
+release-please bumps `package.json` via a PR commit, but `bun.lock` is not automatically reconciled. Any `bun pm pack` run after the bump but before a dependency-triggering `bun install` will embed the old version. Safest CI mitigation: run plain `bun install` (not `--lockfile-only`) as part of the pack/publish step.


### PR DESCRIPTION
## Summary

- Adds the initial `.please/docs/research/` index (`README.md`) so future research entries have a landing point.
- Adds entry 001 documenting the `bun pm pack` + `workspace:*` + stale `bun.lock` interaction (oven-sh/bun#20477 + #18906) — the reason the release workflow regenerates the lockfile before packing.

## Test plan

- [x] Markdown renders correctly on GitHub
- [x] Index table links resolve to `md/001-...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a research index and an entry on a `bun pm pack` + `workspace:*` bug that reads stale versions from `bun.lock`. Explains workarounds and why CI refreshes the lockfile before packing.

- **New Features**
  - Research index at `.please/docs/research/README.md` with a table of recent entries.
  - Entry `001` covers the stale `bun.lock` version issue in `bun pm pack`, links upstream issues, and notes CI mitigation steps.

<sup>Written for commit 537258e99d37ff26a5f2f5a145d15a02c93488b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

