### PR TITLE
fix(cli): fall back to master when default branch is not main

### DIFF
--- a/packages/cli/src/sources/github.ts
+++ b/packages/cli/src/sources/github.ts
@@ -61,16 +61,22 @@ function hasGit(): boolean {
  *
  * When `extraCandidates` are provided (e.g. monorepo tags like
  * `ai@6.0.158` from ecosystem resolvers), they are prepended in order
- * (more specific first). Duplicates are removed — the first occurrence
+ * (more specific first). When `tailCandidates` are provided (e.g.
+ * `master` as a default-branch fallback for `main`), they are appended
+ * (less specific last). Duplicates are removed — the first occurrence
  * wins.
  */
-function refCandidates(ref: string, extraCandidates?: string[]): string[] {
+function refCandidates(
+  ref: string,
+  extraCandidates?: string[],
+  tailCandidates?: string[],
+): string[] {
   const base = ref.startsWith('v') ? [ref] : [ref, `v${ref}`]
-  if (!extraCandidates?.length)
+  if (!extraCandidates?.length && !tailCandidates?.length)
     return base
   const seen = new Set<string>()
   const result: string[] = []
-  for (const c of [...extraCandidates, ...base]) {
+  for (const c of [...(extraCandidates ?? []), ...base, ...(tailCandidates ?? [])]) {
     if (!seen.has(c)) {
       seen.add(c)
       result.push(c)
@@ -185,8 +191,9 @@ function cloneAtTag(
   tmpDir: string,
   extraCandidates?: string[],
   tagOnly?: boolean,
+  tailCandidates?: string[],
 ): { commit: string, winningCandidate: string } {
-  const candidates = refCandidates(ref, extraCandidates)
+  const candidates = refCandidates(ref, extraCandidates, tailCandidates)
   let lastErr: unknown
   for (const candidate of candidates) {
     try {
@@ -234,10 +241,20 @@ function cloneAtTag(
   )
 }
 
+/**
+ * Default-branch fallback chain used when the caller supplied neither
+ * `tag` nor `branch`. GitHub's modern default is `main`, but a large
+ * number of repos (especially older ones) still ship `master`. Trying
+ * `master` after `main` covers the long tail without requiring the user
+ * to guess the default branch name.
+ */
+const DEFAULT_BRANCH_FALLBACKS = ['master']
+
 export class GithubSource implements DocSource {
   async fetch(options: SourceConfig): Promise<FetchResult> {
     const opts = options as GithubSourceOptions
     const { repo, docsPath } = opts
+    const isDefaultRef = opts.tag === undefined && opts.branch === undefined
     const ref = opts.tag ?? opts.branch ?? 'main'
     const [owner, repoName] = repo.split('/')
 
@@ -255,12 +272,16 @@ export class GithubSource implements DocSource {
     const resolvedVersion = tagVersion ?? opts.version
     const askHome = resolveAskHome()
     const fallbackRefs = opts.fallbackRefs
+    // Only add `master` (and friends) when the caller did not specify
+    // a tag or branch. An explicit `branch: 'main'` must stay literal
+    // — silently falling through to `master` would surprise users.
+    const tailCandidates = isDefaultRef ? DEFAULT_BRANCH_FALLBACKS : undefined
 
     // Store-hit path: for each candidate key, check the new nested
     // layout and verify integrity before trusting it. Callers may have
     // given us `1.0.0` while the store holds `v1.0.0`, or vice versa.
     // Also check any fallbackRefs (e.g. monorepo tags like `ai@6.0.158`).
-    for (const candidate of refCandidates(ref, fallbackRefs)) {
+    for (const candidate of refCandidates(ref, fallbackRefs, tailCandidates)) {
       const storeDir = githubStorePath(askHome, DEFAULT_GITHUB_HOST, owner, repoName, candidate)
       if (!fs.existsSync(storeDir))
         continue
@@ -293,6 +314,7 @@ export class GithubSource implements DocSource {
           remoteUrl,
           askHome,
           fallbackRefs,
+          tailCandidates,
         )
       }
       catch (err) {
@@ -304,7 +326,7 @@ export class GithubSource implements DocSource {
       }
     }
 
-    return this.fetchFromTarGz(opts, repo, owner, repoName, ref, resolvedVersion, docsPath, askHome, fallbackRefs)
+    return this.fetchFromTarGz(opts, repo, owner, repoName, ref, resolvedVersion, docsPath, askHome, fallbackRefs, tailCandidates)
   }
 
   private async fetchViaShallowClone(
@@ -318,10 +340,11 @@ export class GithubSource implements DocSource {
     remoteUrl: string,
     askHome: string,
     fallbackRefs?: string[],
+    tailCandidates?: string[],
   ): Promise<FetchResult> {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ask-gh-clone-'))
     try {
-      const { commit, winningCandidate } = cloneAtTag(remoteUrl, ref, tmpDir, fallbackRefs, opts.tag !== undefined)
+      const { commit, winningCandidate } = cloneAtTag(remoteUrl, ref, tmpDir, fallbackRefs, opts.tag !== undefined, tailCandidates)
       const storeDir = githubStorePath(askHome, DEFAULT_GITHUB_HOST, owner, repoName, winningCandidate)
 
       const lock = await acquireEntryLock(storeDir)
@@ -360,14 +383,20 @@ export class GithubSource implements DocSource {
     docsPath: string | undefined,
     askHome: string,
     fallbackRefs?: string[],
+    tailCandidates?: string[],
   ): Promise<FetchResult> {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ask-gh-tar-'))
-    const candidates = refCandidates(ref, fallbackRefs)
+    const candidates = refCandidates(ref, fallbackRefs, tailCandidates)
     let lastErr: unknown
 
     try {
       for (const candidate of candidates) {
-        const archiveUrl = `https://github.com/${repo}/archive/refs/${opts.tag ? 'tags' : 'heads'}/${candidate}.tar.gz`
+        // Tag requests use /archive/refs/tags/, branch requests use
+        // /archive/refs/heads/. When we synthesize tail candidates for
+        // the default-branch case (e.g. `master`), those are always
+        // branches even though the original ref was the default `main`.
+        const isTagCandidate = opts.tag !== undefined && !tailCandidates?.includes(candidate)
+        const archiveUrl = `https://github.com/${repo}/archive/refs/${isTagCandidate ? 'tags' : 'heads'}/${candidate}.tar.gz`
 
         let response: Response
         try {

--- a/packages/cli/test/sources/github.test.ts
+++ b/packages/cli/test/sources/github.test.ts
@@ -344,6 +344,117 @@ describe('GithubSource — nested store layout', () => {
   })
 })
 
+describe('default-branch fallback — main → master', () => {
+  /**
+   * Create a local remote whose default branch is `master` (no `main`).
+   * This simulates older repos (pre-2020) that never migrated to `main`.
+   */
+  function createMasterDefaultRemote(): string {
+    const repoDir = path.join(tmpDir, 'master-remote.git')
+    const workDir = path.join(tmpDir, 'master-work')
+
+    fs.mkdirSync(workDir, { recursive: true })
+    execFileSync('git', ['init', '-b', 'master', workDir], { stdio: 'ignore' })
+    execFileSync('git', ['-C', workDir, 'config', 'user.email', 'test@test.com'], { stdio: 'ignore' })
+    execFileSync('git', ['-C', workDir, 'config', 'user.name', 'Test'], { stdio: 'ignore' })
+
+    fs.writeFileSync(path.join(workDir, 'README.md'), '# Master Default\n')
+    fs.mkdirSync(path.join(workDir, 'docs'))
+    fs.writeFileSync(path.join(workDir, 'docs', 'guide.md'), '# Master Guide\n')
+
+    execFileSync('git', ['-C', workDir, 'add', '-A'], { stdio: 'ignore' })
+    execFileSync('git', ['-C', workDir, 'commit', '-m', 'initial'], { stdio: 'ignore' })
+
+    execFileSync('git', ['clone', '--bare', workDir, repoDir], { stdio: 'ignore' })
+    return repoDir
+  }
+
+  it('falls back to master when no tag/branch is specified and main is absent', async () => {
+    // Regression test: a repo whose default branch is `master` must
+    // clone successfully when the caller supplies neither `tag` nor
+    // `branch`. Without the fallback, the ref defaults to `main`,
+    // the clone fails, and the user sees a confusing error.
+    const remoteUrl = createMasterDefaultRemote()
+    const source = new GithubSource()
+
+    const result = await source.fetch({
+      source: 'github',
+      name: 'master-repo',
+      version: 'main',
+      repo: 'test/master-repo',
+      docsPath: 'docs',
+      remoteUrl,
+    } as any)
+
+    expect(result.storePath).toContain('master')
+    expect(fs.readFileSync(path.join(result.storePath!, 'docs', 'guide.md'), 'utf-8'))
+      .toBe('# Master Guide\n')
+  })
+
+  it('does NOT fall back to master when branch=main is explicit', async () => {
+    // Invariant: an explicit `branch: 'main'` must fail rather than
+    // silently resolve to `master`. Otherwise a typo-free but wrong
+    // branch name could pick up unrelated content.
+    const remoteUrl = createMasterDefaultRemote()
+    const source = new GithubSource()
+
+    let capturedError: Error | null = null
+    try {
+      await source.fetch({
+        source: 'github',
+        name: 'some-pkg',
+        version: '1.0.0',
+        repo: 'test/some-pkg',
+        branch: 'main',
+        docsPath: 'docs',
+        remoteUrl,
+      } as any)
+    }
+    catch (err) {
+      capturedError = err as Error
+    }
+
+    expect(capturedError).not.toBeNull()
+    const message = capturedError!.message
+    expect(message).toContain('main')
+    // The error must NOT list `master` as a tried candidate — explicit
+    // branch requests stay literal. Inspect the `tried: ...` list
+    // specifically (not the whole message) so unrelated repo/branch
+    // names don't accidentally trip the assertion.
+    expect(message).not.toMatch(/tried:[^)]*\bmaster\b/)
+  })
+
+  it('lists master in the tried candidates when both main and master fail', async () => {
+    // Build an empty bare repo (no commits, no branches) so every
+    // clone attempt fails. The thrown error's `(tried: ...)` list must
+    // include `main`, `vmain`, and `master` — confirming the tail
+    // candidate is wired through the clone path.
+    const repoDir = path.join(tmpDir, 'empty-remote.git')
+    execFileSync('git', ['init', '--bare', repoDir], { stdio: 'ignore' })
+    const source = new GithubSource()
+
+    let capturedError: Error | null = null
+    try {
+      await source.fetch({
+        source: 'github',
+        name: 'empty-repo',
+        version: 'main',
+        repo: 'test/empty-repo',
+        docsPath: 'docs',
+        remoteUrl: repoDir,
+      } as any)
+    }
+    catch (err) {
+      capturedError = err as Error
+    }
+
+    expect(capturedError).not.toBeNull()
+    const message = capturedError!.message
+    expect(message).toContain('main')
+    expect(message).toContain('master')
+  })
+})
+
 describe('refCandidates via fetch behavior — fallbackRefs', () => {
   /**
    * Create a local remote with monorepo-style tags (e.g. `ai@6.0.158`).


### PR DESCRIPTION
## Summary

- **Root cause**: `GithubSource` hardcoded `main` as the sole default branch candidate when neither `tag` nor `branch` was specified, causing clones of older repos (e.g. `gitbutlerapp/gitbutler`) to fail with a cryptic error.
- **Fix**: A `DEFAULT_BRANCH_FALLBACKS = ['master']` constant is appended as tail candidates — but only when both `opts.tag` and `opts.branch` are `undefined`. Explicit `branch: 'main'` requests remain literal with no silent fallback.
- **Scope**: Change is strictly confined to the implicit-default-ref code path; all explicit tag/branch requests are unaffected.

## Repro

Before this fix, running `ask install` on a repo whose default branch is `master` produced:

```
git clone failed for gitbutlerapp/gitbutler@main ... (tried: main, vmain)
```

## Test plan

- [x] **New test**: master-only remote clones successfully with no `tag`/`branch` supplied
- [x] **New test**: explicit `branch: 'main'` does NOT fall back to `master`
- [x] **New test**: error message lists `master` in tried candidates when both `main` and `master` fail
- [x] `bun run --cwd packages/cli lint` — clean
- [x] `bun run --cwd packages/cli test` — 465 pass / 0 fail (includes 3 new tests)
- [x] `bun run build` (turbo monorepo) — 3/3 successful

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fall back to `master` when no tag or branch is provided and `main` doesn’t exist. This fixes installs for older repos and makes the “tried candidates” error clearer.

- **Bug Fixes**
  - Added `DEFAULT_BRANCH_FALLBACKS = ['master']` used only when both `tag` and `branch` are undefined. Explicit `branch: 'main'` and any `tag` remain literal.
  - Updated `refCandidates` to accept tail candidates and wired it through shallow clone and tar.gz paths; tail candidates use `/archive/refs/heads/`.
  - Store reuse now checks tail candidates, so previous `master` clones are reused.
  - Tests: added cases for default fallback to `master`, no fallback when `branch: 'main'`, and error messages listing `master` when all candidates fail.

<sup>Written for commit 26d1dd7888487a7a1c29a409f0c3c40058868a81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

