### PR TITLE
fix(cli): propagate default-branch fallback through ensureCheckout

### DIFF
--- a/packages/cli/src/commands/ensure-checkout.ts
+++ b/packages/cli/src/commands/ensure-checkout.ts
@@ -127,6 +127,14 @@ export async function ensureCheckout(
   let npmPackageName: string | undefined
   let fallbackRefs: string[] | undefined
   let isFromBranch = false
+  // True when the caller supplied a bare `github:owner/repo` with no
+  // explicit @ref — we default to 'main' here for the cache-key but must
+  // leave BOTH `tag` and `branch` undefined so GithubSource sees the
+  // "no preference" state and applies its default-branch fallback chain
+  // (main → vmain → master). Passing `branch: 'main'` would lock the
+  // source into that literal branch and repos whose default is `master`
+  // (e.g. gitbutlerapp/gitbutler) would fail.
+  let isImplicitDefaultRef = false
 
   if (parsed.kind === 'github') {
     // Direct github spec — owner/repo from parse, ref from explicit @version or 'main'
@@ -135,6 +143,7 @@ export async function ensureCheckout(
     ref = explicitVersion ?? 'main'
     resolvedVersion = ref
     isFromBranch = !explicitVersion // 'main' is a branch, explicit refs are tags
+    isImplicitDefaultRef = !explicitVersion
   }
   else {
     // npm-prefixed, bare-name, or other ecosystem prefix → resolver dispatch
@@ -203,13 +212,19 @@ export async function ensureCheckout(
     throw new NoCacheError(checkoutDir, options.spec)
   }
 
-  // 7. Trigger the fetch via the existing GithubSource pipeline
+  // 7. Trigger the fetch via the existing GithubSource pipeline.
+  //    For implicit default refs, pass NEITHER `tag` nor `branch` so
+  //    GithubSource.fetch can activate its default-branch fallback
+  //    chain (main → vmain → master).
+  const refOpt: Partial<GithubSourceOptions> = isImplicitDefaultRef
+    ? {}
+    : isFromBranch ? { branch: ref } : { tag: ref }
   const fetchOpts: GithubSourceOptions = {
     source: 'github',
     name: parsed.name,
     version: resolvedVersion,
     repo: `${owner}/${repo}`,
-    ...(isFromBranch ? { branch: ref } : { tag: ref }),
+    ...refOpt,
     ...(fallbackRefs?.length ? { fallbackRefs } : {}),
   }
   const fetchResult = await fetcher.fetch(fetchOpts)

--- a/packages/cli/test/commands/ensure-checkout.integration.test.ts
+++ b/packages/cli/test/commands/ensure-checkout.integration.test.ts
@@ -36,11 +36,13 @@ afterEach(() => {
 describe('ensureCheckout ↔ GithubSource.fetch layout contract', () => {
   it('returns the PM-unified store path that GithubSource.fetch writes to', async () => {
     // Simulate GithubSource.fetch by writing to the real PM-unified layout.
+    // Mirror the source's own default handling: when the caller supplies
+    // neither `tag` nor `branch`, GithubSource defaults to `main`.
     const fetcher = {
       fetch: async (opts: SourceConfig) => {
         const gh = opts as GithubSourceOptions
         const [owner, repo] = gh.repo.split('/')
-        const ref = gh.tag ?? gh.branch!
+        const ref = gh.tag ?? gh.branch ?? 'main'
         const storeDir = githubStorePath(askHome, 'github.com', owner, repo, ref)
         fs.mkdirSync(storeDir, { recursive: true })
         fs.writeFileSync(path.join(storeDir, 'README.md'), '# test')
@@ -115,7 +117,7 @@ describe('ensureCheckout ↔ GithubSource.fetch layout contract', () => {
       fetch: async (opts: SourceConfig) => {
         const gh = opts as GithubSourceOptions
         const [owner, repo] = gh.repo.split('/')
-        const ref = gh.tag ?? gh.branch!
+        const ref = gh.tag ?? gh.branch ?? 'main'
         const storeDir = githubStorePath(askHome, 'github.com', owner, repo, ref)
         fs.mkdirSync(path.join(storeDir, 'docs'), { recursive: true })
         return { files: [], resolvedVersion: ref, storePath: storeDir }

--- a/packages/cli/test/commands/ensure-checkout.test.ts
+++ b/packages/cli/test/commands/ensure-checkout.test.ts
@@ -254,8 +254,36 @@ describe('ensureCheckout', () => {
     expect(result.ref).toBe('main')
     expect(result.checkoutDir).toBe(expectedDir)
     expect(calls).toHaveLength(1)
-    expect(calls[0].opts.branch).toBe('main')
+    // Implicit default ref: pass NEITHER `tag` nor `branch` so
+    // GithubSource can apply its default-branch fallback chain
+    // (main → vmain → master). Setting `branch: 'main'` would defeat
+    // the fallback for repos whose default branch is `master`.
+    expect(calls[0].opts.branch).toBeUndefined()
     expect(calls[0].opts.tag).toBeUndefined()
+  })
+
+  it('omits tag/branch for bare github spec so master fallback in GithubSource activates', async () => {
+    // Regression for: `bunx @pleaseai/ask src github:gitbutlerapp/gitbutler`
+    // failing with `tried: main, vmain` because `ensureCheckout` passed
+    // `branch: 'main'` and forced `GithubSource.isDefaultRef = false`.
+    const { fetcher, calls } = makeFetcher(() => {
+      const dir = path.join(askHome, 'github', 'github.com', 'gitbutlerapp', 'gitbutler', 'main')
+      fs.mkdirSync(dir, { recursive: true })
+    })
+
+    await ensureCheckout(
+      { spec: 'github:gitbutlerapp/gitbutler', projectDir },
+      {
+        askHome,
+        fetcher,
+        resolverFor: () => null,
+        lockfileReader: { read: () => null },
+      },
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].opts.tag).toBeUndefined()
+    expect(calls[0].opts.branch).toBeUndefined()
   })
 
   it('handles github: spec with explicit @ref', async () => {


### PR DESCRIPTION
## Problem

**Symptom:** `bunx @pleaseai/ask src github:gitbutlerapp/gitbutler` on v0.4.3 still fails with `tried: main, vmain` — the `master` fallback from #92 never fires.

**Root cause:** `ensureCheckout` (used by both `ask src` and `ask docs`) unconditionally passed `{ branch: 'main' }` to `GithubSource.fetch` for bare `github:owner/repo` specs (no explicit `@ref`). The `main → vmain → master` fallback chain in `GithubSource` is gated on `isDefaultRef = opts.tag === undefined && opts.branch === undefined`. Because `branch` was always `'main'`, `isDefaultRef` was always `false`, so the fallback never activated on these paths.

## Fix

Three files, one logical change:

- **`packages/cli/src/commands/ensure-checkout.ts`** — introduce `isImplicitDefaultRef`; when a bare `github:owner/repo` spec has no `@ref`, pass neither `tag` nor `branch` to `GithubSource.fetch` so its `isDefaultRef` check fires and the `main → vmain → master` chain runs.
- **`packages/cli/test/commands/ensure-checkout.test.ts`** — update the test that locked in the buggy `branch: 'main'` behaviour; add a gitbutler-specific regression test.
- **`packages/cli/test/commands/ensure-checkout.integration.test.ts`** — update the mock fetcher to mirror `GithubSource`'s own `?? 'main'` default handling (`gh.tag ?? gh.branch ?? 'main'` instead of `gh.tag ?? gh.branch!`).

## Test Plan

- [x] `bun run --cwd packages/cli test` — 466 pass / 0 fail
- [x] `bun run --cwd packages/cli build` — tsc clean
- [x] `bun run --cwd packages/cli lint` — clean
- [ ] Manual: `bunx @pleaseai/ask@<next> src github:gitbutlerapp/gitbutler` returns the checkout path without the `tried: main, vmain` warning.

## Notes

This does not need a new issue — it completes the fix started in #92 (`dc8efef`). The `master` fallback was correctly implemented in `GithubSource` but never reached the `src`/`docs` paths due to the `ensureCheckout` call site always supplying `branch: 'main'`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes default-branch fallback for bare GitHub specs in the CLI by letting `GithubSource` run its main → vmain → master chain. This resolves failures like `bunx @pleaseai/ask src github:gitbutlerapp/gitbutler` on repos with `master` as default.

- **Bug Fixes**
  - In `ensureCheckout`, when no explicit `@ref`, stop sending `branch: 'main'`; leave `tag` and `branch` undefined so `GithubSource.fetch` activates its fallback.
  - Updated tests: removed assertion for `branch: 'main'`, added a regression test for gitbutler, and aligned the integration mock to `gh.tag ?? gh.branch ?? 'main'`.

<sup>Written for commit b7f8e56571c72b2895254db891841c732ad82c1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

