### PR TITLE
fix(cli): strip removed library from AGENTS.md on ask remove

### DIFF
--- a/packages/cli/src/agents.ts
+++ b/packages/cli/src/agents.ts
@@ -3,6 +3,8 @@ import path from 'node:path'
 
 const BEGIN_MARKER = '<!-- BEGIN:ask-docs-auto-generated -->'
 const END_MARKER = '<!-- END:ask-docs-auto-generated -->'
+const TRAILING_NEWLINES_RE = /\n+$/
+const LEADING_NEWLINES_RE = /^\n+/
 
 export interface LazyLibraryInfo {
   name: string
@@ -14,8 +16,33 @@ export function generateAgentsMd(
   projectDir: string,
   libraries: LazyLibraryInfo[],
 ): string {
-  if (libraries.length === 0)
+  const agentsPath = path.join(projectDir, 'AGENTS.md')
+
+  if (libraries.length === 0) {
+    // Strip any previously generated block so removed libraries don't
+    // linger in AGENTS.md after the last entry is removed from ask.json.
+    if (fs.existsSync(agentsPath)) {
+      const existing = fs.readFileSync(agentsPath, 'utf-8')
+      const beginIdx = existing.indexOf(BEGIN_MARKER)
+      const endIdx = existing.indexOf(END_MARKER)
+      if (beginIdx !== -1 && endIdx !== -1) {
+        const head = existing.substring(0, beginIdx).replace(TRAILING_NEWLINES_RE, '')
+        const tail = existing.substring(endIdx + END_MARKER.length).replace(LEADING_NEWLINES_RE, '')
+        const stripped = head.length === 0
+          ? tail
+          : tail.length === 0
+            ? `${head}\n`
+            : `${head}\n\n${tail}`
+        if (stripped.length === 0) {
+          fs.rmSync(agentsPath)
+        }
+        else {
+          fs.writeFileSync(agentsPath, stripped, 'utf-8')
+        }
+      }
+    }
     return ''
+  }
 
   const sections = libraries.map(({ name, version }) => {
     const major = version.split('.')[0]
@@ -51,8 +78,6 @@ fd "\\.md$" "$(ask docs <package> | head -n 1)"
 
 ${sections.join('\n\n')}
 ${END_MARKER}`
-
-  const agentsPath = path.join(projectDir, 'AGENTS.md')
 
   if (fs.existsSync(agentsPath)) {
     const existing = fs.readFileSync(agentsPath, 'utf-8')

--- a/packages/cli/src/agents.ts
+++ b/packages/cli/src/agents.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { consola } from 'consola'
 
 const BEGIN_MARKER = '<!-- BEGIN:ask-docs-auto-generated -->'
 const END_MARKER = '<!-- END:ask-docs-auto-generated -->'
@@ -39,6 +40,14 @@ export function generateAgentsMd(
         else {
           fs.writeFileSync(agentsPath, stripped, 'utf-8')
         }
+      }
+      else if (beginIdx !== -1 || endIdx !== -1) {
+        // Mismatched markers — likely truncated or hand-edited. Leave the
+        // file alone so the user can repair it rather than silently emitting
+        // further corruption on the next install.
+        consola.warn(
+          `${path.relative(projectDir, agentsPath) || 'AGENTS.md'} has an unmatched ask-docs marker — leaving file untouched. Inspect manually to restore the <!-- BEGIN:ask-docs-auto-generated --> / <!-- END:ask-docs-auto-generated --> pair.`,
+        )
       }
     }
     return ''

--- a/packages/cli/src/install.ts
+++ b/packages/cli/src/install.ts
@@ -48,15 +48,23 @@ export async function runInstall(
     ? askJson.libraries.filter(s => options.onlySpecs!.includes(s))
     : askJson.libraries
 
+  const summary: InstallSummary = { installed: 0, skipped: 0 }
+  const resolved: LazyLibraryInfo[] = []
+
   if (targets.length === 0) {
+    // No targets can mean either a scoped install with a bogus --only-specs,
+    // or a full install after the last library was removed. In the latter
+    // case we still need to regenerate AGENTS.md so the auto-generated block
+    // is stripped rather than left pointing at the removed entry.
+    if (!options.onlySpecs) {
+      generateAgentsMd(projectDir, [])
+      manageIgnoreFiles(projectDir, 'remove')
+    }
     consola.info('No libraries to install.')
-    return { installed: 0, skipped: 0 }
+    return summary
   }
 
   consola.start(`Resolving ${targets.length} librar${targets.length === 1 ? 'y' : 'ies'}...`)
-
-  const summary: InstallSummary = { installed: 0, skipped: 0 }
-  const resolved: LazyLibraryInfo[] = []
 
   for (const spec of targets) {
     const result = resolveOne(projectDir, spec)

--- a/packages/cli/test/install/remove.test.ts
+++ b/packages/cli/test/install/remove.test.ts
@@ -4,6 +4,7 @@ import process from 'node:process'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { runMain } from 'citty'
 import { main } from '../../src/index.js'
+import { runInstall } from '../../src/install.js'
 import { readAskJson, writeAskJson } from '../../src/io.js'
 
 async function runCli(cwd: string, args: string[]): Promise<void> {
@@ -125,5 +126,67 @@ describe('ask remove (lazy-first)', () => {
     expect(afterRemove).not.toContain('<!-- BEGIN:ask-docs-auto-generated -->')
     expect(afterRemove).not.toContain('<!-- END:ask-docs-auto-generated -->')
     expect(afterRemove).not.toContain('next v16.2.3')
+  })
+
+  it('preserves user content written AFTER the auto-generated block', async () => {
+    writeLockedPkg(tmpDir, {
+      next: { range: '^16.0.0', resolved: '16.2.3' },
+    })
+    writeAskJson(tmpDir, { libraries: ['npm:next'] })
+
+    await runCli(tmpDir, ['install'])
+    const agentsPath = path.join(tmpDir, 'AGENTS.md')
+
+    // Append user content AFTER the auto-generated block so the block sits
+    // at the top, not the bottom. Exercises the `head.length === 0 ? tail`
+    // branch of the strip logic.
+    const afterInstall = fs.readFileSync(agentsPath, 'utf-8')
+    fs.writeFileSync(agentsPath, `${afterInstall}\n# Post-block notes\n\nHand-written after install.\n`)
+
+    await runCli(tmpDir, ['remove', 'next'])
+
+    const afterRemove = fs.readFileSync(agentsPath, 'utf-8')
+    expect(afterRemove).toContain('# Post-block notes')
+    expect(afterRemove).toContain('Hand-written after install.')
+    expect(afterRemove).not.toContain('<!-- BEGIN:ask-docs-auto-generated -->')
+    expect(afterRemove).not.toContain('next v16.2.3')
+  })
+
+  it('leaves AGENTS.md untouched and warns when only one marker is present', async () => {
+    writeLockedPkg(tmpDir, {
+      next: { range: '^16.0.0', resolved: '16.2.3' },
+    })
+    writeAskJson(tmpDir, { libraries: ['npm:next'] })
+
+    // Hand-corrupt AGENTS.md: BEGIN marker only, no END.
+    const agentsPath = path.join(tmpDir, 'AGENTS.md')
+    const corruptedContent
+      = '# Project\n\n<!-- BEGIN:ask-docs-auto-generated -->\n(block was truncated)\n\n## Notes\nUser text after orphan marker.\n'
+    fs.writeFileSync(agentsPath, corruptedContent)
+
+    await runCli(tmpDir, ['remove', 'next'])
+
+    const afterRemove = fs.readFileSync(agentsPath, 'utf-8')
+    expect(afterRemove).toBe(corruptedContent)
+  })
+
+  it('leaves AGENTS.md untouched when onlySpecs matches nothing in ask.json', async () => {
+    writeLockedPkg(tmpDir, {
+      next: { range: '^16.0.0', resolved: '16.2.3' },
+    })
+    writeAskJson(tmpDir, { libraries: ['npm:next'] })
+    await runCli(tmpDir, ['install'])
+
+    const agentsPath = path.join(tmpDir, 'AGENTS.md')
+    const beforeScoped = fs.readFileSync(agentsPath, 'utf-8')
+    expect(beforeScoped).toContain('next v16.2.3')
+
+    // Scoped install where onlySpecs is not in ask.json → targets=[] but the
+    // !options.onlySpecs guard must skip the AGENTS.md wipe. Regression test
+    // for the guard in runInstall at the empty-targets branch.
+    await runInstall(tmpDir, { onlySpecs: ['npm:not-in-ask-json'] })
+
+    const afterScoped = fs.readFileSync(agentsPath, 'utf-8')
+    expect(afterScoped).toBe(beforeScoped)
   })
 })

--- a/packages/cli/test/install/remove.test.ts
+++ b/packages/cli/test/install/remove.test.ts
@@ -1,6 +1,44 @@
 import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { runMain } from 'citty'
+import { main } from '../../src/index.js'
 import { readAskJson, writeAskJson } from '../../src/io.js'
+
+async function runCli(cwd: string, args: string[]): Promise<void> {
+  const original = process.cwd()
+  const originalArgv = process.argv
+  process.chdir(cwd)
+  process.argv = ['node', 'ask', ...args]
+  try {
+    await runMain(main)
+  }
+  finally {
+    process.chdir(original)
+    process.argv = originalArgv
+  }
+}
+
+function writeLockedPkg(
+  tmpDir: string,
+  deps: Record<string, { range: string, resolved: string }>,
+): void {
+  const depsJson: Record<string, string> = {}
+  const lockPackages: Record<string, [string, string, Record<string, unknown>, string]> = {}
+  for (const [name, { range, resolved }] of Object.entries(deps)) {
+    depsJson[name] = range
+    lockPackages[name] = [`${name}@${resolved}`, '', {}, 'sha512-abc']
+  }
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({ dependencies: depsJson }),
+  )
+  fs.writeFileSync(
+    path.join(tmpDir, 'bun.lock'),
+    JSON.stringify({ lockfileVersion: 0, packages: lockPackages }),
+  )
+}
 
 describe('ask remove (lazy-first)', () => {
   let tmpDir: string
@@ -23,5 +61,69 @@ describe('ask remove (lazy-first)', () => {
 
     const updated = readAskJson(tmpDir)!
     expect(updated.libraries).toEqual(['npm:zod'])
+  })
+
+  it('strips the removed library section from AGENTS.md', async () => {
+    writeLockedPkg(tmpDir, {
+      next: { range: '^16.0.0', resolved: '16.2.3' },
+      zod: { range: '^3.0.0', resolved: '3.22.1' },
+    })
+    writeAskJson(tmpDir, { libraries: ['npm:next', 'npm:zod'] })
+    await runCli(tmpDir, ['install'])
+
+    const agentsPath = path.join(tmpDir, 'AGENTS.md')
+    const beforeRemove = fs.readFileSync(agentsPath, 'utf-8')
+    expect(beforeRemove).toContain('next v16.2.3')
+    expect(beforeRemove).toContain('zod v3.22.1')
+
+    await runCli(tmpDir, ['remove', 'next'])
+
+    const afterRemove = fs.readFileSync(agentsPath, 'utf-8')
+    expect(afterRemove).not.toContain('next v16.2.3')
+    expect(afterRemove).not.toContain('ask docs next')
+    expect(afterRemove).toContain('zod v3.22.1')
+  })
+
+  it('strips the whole auto-generated block when the last library is removed', async () => {
+    writeLockedPkg(tmpDir, {
+      next: { range: '^16.0.0', resolved: '16.2.3' },
+    })
+    writeAskJson(tmpDir, { libraries: ['npm:next'] })
+    await runCli(tmpDir, ['install'])
+
+    const agentsPath = path.join(tmpDir, 'AGENTS.md')
+    const beforeRemove = fs.readFileSync(agentsPath, 'utf-8')
+    expect(beforeRemove).toContain('<!-- BEGIN:ask-docs-auto-generated -->')
+    expect(beforeRemove).toContain('next v16.2.3')
+
+    await runCli(tmpDir, ['remove', 'next'])
+
+    // AGENTS.md had ONLY the auto-generated block, so after stripping it
+    // the file is empty and gets deleted.
+    expect(fs.existsSync(agentsPath)).toBe(false)
+  })
+
+  it('preserves user content in AGENTS.md when the last library is removed', async () => {
+    writeLockedPkg(tmpDir, {
+      next: { range: '^16.0.0', resolved: '16.2.3' },
+    })
+    writeAskJson(tmpDir, { libraries: ['npm:next'] })
+
+    const agentsPath = path.join(tmpDir, 'AGENTS.md')
+    fs.writeFileSync(agentsPath, '# My Project\n\nHand-written notes here.\n')
+
+    await runCli(tmpDir, ['install'])
+    const beforeRemove = fs.readFileSync(agentsPath, 'utf-8')
+    expect(beforeRemove).toContain('# My Project')
+    expect(beforeRemove).toContain('<!-- BEGIN:ask-docs-auto-generated -->')
+
+    await runCli(tmpDir, ['remove', 'next'])
+
+    const afterRemove = fs.readFileSync(agentsPath, 'utf-8')
+    expect(afterRemove).toContain('# My Project')
+    expect(afterRemove).toContain('Hand-written notes here.')
+    expect(afterRemove).not.toContain('<!-- BEGIN:ask-docs-auto-generated -->')
+    expect(afterRemove).not.toContain('<!-- END:ask-docs-auto-generated -->')
+    expect(afterRemove).not.toContain('next v16.2.3')
   })
 })

--- a/packages/cli/test/install/remove.test.ts
+++ b/packages/cli/test/install/remove.test.ts
@@ -152,16 +152,17 @@ describe('ask remove (lazy-first)', () => {
     expect(afterRemove).not.toContain('next v16.2.3')
   })
 
-  it('leaves AGENTS.md untouched and warns when only one marker is present', async () => {
+  const orphanMarkerCases: Array<[string, string]> = [
+    ['BEGIN', '# Project\n\n<!-- BEGIN:ask-docs-auto-generated -->\n(block was truncated)\n\n## Notes\nUser text after orphan marker.\n'],
+    ['END', '# Project\n\n(block header was deleted)\n<!-- END:ask-docs-auto-generated -->\n\n## Notes\nUser text after orphan marker.\n'],
+  ]
+  it.each(orphanMarkerCases)('leaves AGENTS.md untouched and warns when only the %s marker is present', async (_label, corruptedContent) => {
     writeLockedPkg(tmpDir, {
       next: { range: '^16.0.0', resolved: '16.2.3' },
     })
     writeAskJson(tmpDir, { libraries: ['npm:next'] })
 
-    // Hand-corrupt AGENTS.md: BEGIN marker only, no END.
     const agentsPath = path.join(tmpDir, 'AGENTS.md')
-    const corruptedContent
-      = '# Project\n\n<!-- BEGIN:ask-docs-auto-generated -->\n(block was truncated)\n\n## Notes\nUser text after orphan marker.\n'
     fs.writeFileSync(agentsPath, corruptedContent)
 
     await runCli(tmpDir, ['remove', 'next'])


### PR DESCRIPTION
## Summary

- Fix `ask remove` leaving the removed library's section (or the whole auto-generated block) in `AGENTS.md` when the last entry is removed from `ask.json`
- `runInstall` now regenerates `AGENTS.md` even when the full install has zero targets (previously short-circuited without touching the file)
- `generateAgentsMd` now strips the existing `<!-- BEGIN:ask-docs-auto-generated --> … <!-- END -->` block on empty input: deletes `AGENTS.md` when only the block remained, preserves user-authored content otherwise
- Added 3 CLI-level tests covering non-last removal, last-library removal (file deleted), and user content preservation

## Root cause

Two cooperating early returns skipped regeneration when `askJson.libraries` became empty:

1. `runInstall` short-circuited on `targets.length === 0` before calling `generateAgentsMd`
2. `generateAgentsMd` returned `''` on `libraries.length === 0` without touching `AGENTS.md`

The happy path (remove a non-last library) worked because `runInstall` still hit the regeneration call with the remaining libraries.

## Test plan

- [x] `bun run --cwd packages/cli test test/install/remove.test.ts` — 4 pass
- [x] `bun run --cwd packages/cli test` — 473 pass / 0 fail
- [x] `bun run --cwd packages/cli lint` — clean
- [x] `bun run --cwd packages/cli build` — typecheck clean

## Follow-up (not in this PR)

`ask remove` still does not call `removeFromIntentSkillsBlock`, so intent-format packages leave their `<!-- intent-skills:start -->` entries behind. Tracked for a separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ask remove` leaving stale entries in `AGENTS.md`, ensures the file is cleaned when the last library is removed, and warns on orphaned markers to prevent silent corruption.

- **Bug Fixes**
  - `generateAgentsMd`: on empty input, strips the auto-generated block; deletes `AGENTS.md` if only the block remained; preserves user content; logs a `consola.warn` and leaves the file untouched when markers are mismatched.
  - `runInstall`: when not scoped with `--only-specs` and targets are empty, regenerates `AGENTS.md` and updates ignore files; when scoped and no specs match, skips regeneration.
  - Added CLI tests for removing a single library, removing the last library (file deleted), preserving user content before/after the block, orphan marker warning (BEGIN or END), and the `--only-specs` no-match case.

<sup>Written for commit 1675e4ebca849b59441d2e5aa1a6b54a43485699. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

