### PR TITLE
docs(registry): update README to reflect JSON entry schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,48 +203,93 @@ fallback is on the roadmap.
 
 ## Registry
 
-The ASK Registry (`apps/registry/`) is a community-maintained catalog of library documentation configs. Each entry is a Markdown file with YAML frontmatter:
+The ASK Registry (`apps/registry/`) is a community-maintained catalog of library documentation configs. Each entry is a JSON file keyed by `<github-owner>/<repo>.json`:
 
 ```
 apps/registry/content/registry/
 ├── vercel/           # github owner
-│   └── next.js.md
+│   ├── next.js.json
+│   └── ai.json
 ├── colinhacks/       # github owner
-│   └── zod.md
+│   └── zod.json
 ├── tailwindlabs/     # github owner
-│   └── tailwindcss.md
+│   └── tailwindcss.json
 └── ...               # one directory per github owner
 ```
 
-### Registry entry format
+### Entry → Package → Source hierarchy
 
-```markdown
----
-name: Next.js
-description: The React framework by Vercel
-repo: vercel/next.js
-docsPath: docs
-homepage: https://nextjs.org
-license: MIT
-aliases:
-  - ecosystem: npm
-    name: next
-strategies:
-  - source: npm
-    package: next
-    docsPath: dist/docs
-  - source: github
-    repo: vercel/next.js
-    docsPath: docs
-tags: [react, framework, ssr]
----
+Each entry describes one GitHub repository and declares one or more **packages**. A package is a documentation target (a single library has one, a monorepo has many). Each package declares ordered **sources** the CLI tries head-first with fallback on failure. See [`ADR-0001`](.please/docs/decisions/0001-registry-entry-schema-entry-package-source.md) for the rationale.
 
-Description and version notes here...
+### Single-package entry
+
+```json
+{
+  "name": "Next.js",
+  "description": "The React framework by Vercel",
+  "repo": "vercel/next.js",
+  "homepage": "https://nextjs.org",
+  "license": "MIT",
+  "tags": ["react", "framework", "ssr"],
+  "packages": [
+    {
+      "name": "next",
+      "aliases": [
+        { "ecosystem": "npm", "name": "next" }
+      ],
+      "sources": [
+        { "type": "npm", "package": "next", "path": "dist/docs" },
+        { "type": "github", "repo": "vercel/next.js", "path": "docs" }
+      ]
+    }
+  ]
+}
 ```
+
+### Monorepo entry
+
+One package per documentation target; each owns its own aliases and source chain.
+
+```json
+{
+  "name": "Mastra",
+  "description": "TypeScript framework for building AI agents, workflows, and RAG pipelines",
+  "repo": "mastra-ai/mastra",
+  "packages": [
+    {
+      "name": "@mastra/core",
+      "aliases": [{ "ecosystem": "npm", "name": "@mastra/core" }],
+      "sources": [
+        { "type": "npm", "package": "@mastra/core", "path": "dist/docs" },
+        { "type": "github", "repo": "mastra-ai/mastra", "path": "docs" }
+      ]
+    },
+    {
+      "name": "@mastra/memory",
+      "aliases": [{ "ecosystem": "npm", "name": "@mastra/memory" }],
+      "sources": [
+        { "type": "npm", "package": "@mastra/memory", "path": "dist/docs" },
+        { "type": "github", "repo": "mastra-ai/mastra", "path": "docs" }
+      ]
+    }
+  ]
+}
+```
+
+### Source types
+
+| `type` | Required fields | Optional |
+|---|---|---|
+| `npm` | `package` | `path` (path inside the tarball, e.g. `dist/docs`) |
+| `github` | `repo` (`owner/name`) | `branch` or `tag` (mutually exclusive), `path` |
+| `web` | `urls` (array, non-empty) | `maxDepth`, `allowedPathPrefix` |
+| `llms-txt` | `url` | — |
+
+Supported alias ecosystems: `npm`, `pypi`, `pub`, `go`, `crates`, `hex`, `nuget`, `maven`.
 
 ### Contributing
 
-Add a new `.md` file under `apps/registry/content/registry/<github-owner>/` and submit a PR.
+Add a new `.json` file under `apps/registry/content/registry/<github-owner>/` and submit a PR. The file is validated against the `registryEntrySchema` in [`packages/schema/src/registry.ts`](packages/schema/src/registry.ts) at build time — duplicate aliases, duplicate package names, and slug collisions across packages are all rejected.
 
 ## Ecosystem Resolvers
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Each entry describes one GitHub repository and declares one or more **packages**
   "repo": "vercel/next.js",
   "homepage": "https://nextjs.org",
   "license": "MIT",
-  "tags": ["react", "framework", "ssr"],
+  "tags": ["react", "framework", "ssr", "vercel"],
   "packages": [
     {
       "name": "next",


### PR DESCRIPTION
## Summary

The README's Registry section described the old Markdown+YAML-frontmatter format. The implementation has since migrated to a Nuxt Content v3 `type: 'data'` collection backed by `.json` files and restructured the schema around the Entry → Package → Source hierarchy (ADR-0001). The docs were stale and misleading for contributors.

## Changes

- **File format**: `.md` with YAML frontmatter → `.json` (Nuxt Content v3 `type: 'data'` collection)
- **Schema restructured**: flat `aliases`/`strategies` → Entry → Package → Source hierarchy per ADR-0001
- **Source-type reference table** added: `npm`, `github`, `web`, `llms-txt` with required/optional fields
- **Monorepo example** added: `@mastra/core` and `@mastra/memory` showing multiple packages in one entry
- **Field renames**: `strategies[].source` → `sources[].type`, `docsPath` → `path`, top-level `aliases` → per-package `aliases`
- **Contributing section** updated to point at `registryEntrySchema` in `packages/schema/src/registry.ts` and call out validation invariants (duplicate aliases, duplicate package names, slug collisions)

## Test plan

- [ ] Render README on GitHub and verify code blocks display correctly
- [ ] Confirm all internal links (`ADR-0001`, `packages/schema/src/registry.ts`) resolve
- [ ] Spot-check that the JSON examples match the actual schema in `packages/schema/src/registry.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Registry docs in README to the JSON-based schema and Entry → Package → Source structure, replacing the old Markdown + YAML frontmatter format. Adds a source-type reference, a monorepo example (`@mastra/core`, `@mastra/memory`), field rename notes, updated contributing guidance pointing to validation in `packages/schema/src/registry.ts`, and syncs the Next.js example tags (adds `vercel`) to match the real entry.

<sup>Written for commit f1c73458e22d12c93f82d908aa6aaf4314227f6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

