### PR TITLE
fix(cli): POSIX-normalize docsPaths for cross-platform portability

### DIFF
--- a/.claude/agent-memory/review-review-cubic-reviewer/MEMORY.md
+++ b/.claude/agent-memory/review-review-cubic-reviewer/MEMORY.md
@@ -1,0 +1,3 @@
+# Agent Memory — review-review-cubic-reviewer
+
+- [Cross-platform path normalization fix](feedback_path_normalization.md) — cubic P2 false-positive pattern for path.normalize + cross-platform fix validated clean in second review pass

--- a/.claude/agent-memory/review-review-cubic-reviewer/feedback_path_normalization.md
+++ b/.claude/agent-memory/review-review-cubic-reviewer/feedback_path_normalization.md
@@ -1,0 +1,17 @@
+---
+name: Cross-platform path normalization — cubic false-positive pattern
+description: cubic flags path.normalize for cross-platform issues; fix with path.posix.normalize + replaceAll backslash passes second review cleanly
+type: feedback
+---
+
+In `sanitizeDocsPath`, cubic (P2) flagged `path.normalize(trimmed)` as producing OS-native separators (Windows `\`) that would be persisted into `ask.json`, breaking portability.
+
+Fix pattern: replace `path.normalize(trimmed)` with `path.posix.normalize(trimmed.replaceAll('\\', '/'))` so stored values always use POSIX forward slashes.
+
+Traversal check becomes: `normalized === '..' || normalized.startsWith('../')` — valid because normalized form is guaranteed POSIX after the fix.
+
+**Why:** `ask.json` is committed to git and shared across platforms. Storing Windows-style backslashes in `docsPaths` would break resolution on Linux/macOS.
+
+**How to apply:** Any time paths destined for committed config files are normalized, always use `path.posix.normalize` + backslash conversion, not `path.normalize`. cubic will flag the bare `path.normalize` pattern again if it reappears.
+
+Second-pass cubic review returned zero issues — fix was accepted as complete.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -14,16 +14,21 @@ const OWNER_REPO_RE = /^[^/]+\/[^/]+$/
 /**
  * Validate and canonicalize a user-supplied docs path (either from the
  * interactive prompt or the `--docs-paths` CSV flag). Returns the
- * normalized relative path on success, or null when the input is
- * unsafe / empty. Rejects:
+ * POSIX-normalized relative path on success, or null when the input
+ * is unsafe / empty. Rejects:
  *
  *   - Empty / whitespace-only strings
- *   - Absolute paths (anything `path.isAbsolute` accepts)
+ *   - Absolute paths (anything `path.isAbsolute` accepts — covers
+ *     POSIX `/...`, Windows `C:\...` and UNC `\\server\...`)
  *   - Paths that resolve out of their root via `..` segments
  *
- * Callers store the returned value verbatim; the read side
- * (`ask docs`) re-joins it against the candidate roots and applies
- * its own containment guard as defense-in-depth.
+ * Normalization uses `path.posix.normalize` over a forward-slash
+ * representation of the input so the value persisted in `ask.json`
+ * stays portable across operating systems. A Windows user writing
+ * `docs\api` and a POSIX user writing `docs/api` both produce the
+ * same stored token `docs/api`. The read side (`ask docs`) re-joins
+ * via `path.resolve`, which accepts both separator styles on Windows
+ * and forward slashes on POSIX.
  */
 function sanitizeDocsPath(input: string): string | null {
   const trimmed = input.trim()
@@ -33,15 +38,11 @@ function sanitizeDocsPath(input: string): string | null {
   if (path.isAbsolute(trimmed)) {
     return null
   }
-  const normalized = path.normalize(trimmed)
+  const normalized = path.posix.normalize(trimmed.replaceAll('\\', '/'))
   if (!normalized) {
     return null
   }
-  if (
-    normalized === '..'
-    || normalized.startsWith(`..${path.sep}`)
-    || normalized.startsWith('../')
-  ) {
+  if (normalized === '..' || normalized.startsWith('../')) {
     return null
   }
   return normalized

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -254,6 +254,35 @@ describe('runAdd — --docs-paths flag', () => {
     expect(askJson.libraries[0]).toEqual({ spec: 'npm:zod', docsPaths: ['docs'] })
   })
 
+  it('normalizes backslash separators to forward slashes for cross-platform portability', async () => {
+    await runAdd(
+      { projectDir, spec: 'npm:zod', docsPathsArg: 'docs\\api,dist\\docs' },
+      {
+        gatherCandidates: mock(async () => []) as any,
+        installer: noopInstaller(),
+      },
+    )
+
+    const askJson = readJson(path.join(projectDir, 'ask.json'))
+    expect(askJson.libraries[0]).toEqual({
+      spec: 'npm:zod',
+      docsPaths: ['docs/api', 'dist/docs'],
+    })
+  })
+
+  it('rejects backslash-prefixed parent traversal on any platform', async () => {
+    await runAdd(
+      { projectDir, spec: 'npm:zod', docsPathsArg: '..\\escape,docs' },
+      {
+        gatherCandidates: mock(async () => []) as any,
+        installer: noopInstaller(),
+      },
+    )
+
+    const askJson = readJson(path.join(projectDir, 'ask.json'))
+    expect(askJson.libraries[0]).toEqual({ spec: 'npm:zod', docsPaths: ['docs'] })
+  })
+
   it('drops to bare string when every --docs-paths entry is unsafe', async () => {
     await runAdd(
       { projectDir, spec: 'npm:zod', docsPathsArg: '/abs,../esc' },


### PR DESCRIPTION
## Summary

- Re-applies the cubic P2 fix that was pushed to #101 after it had already been merged, so the change never reached `main`.
- `sanitizeDocsPath` in `packages/cli/src/commands/add.ts` now uses `path.posix.normalize(trimmed.replaceAll('\\', '/'))` so values persisted in `ask.json` always use forward slashes. Windows-authored `docs\api` and POSIX-authored `docs/api` produce the same stored token `docs/api`.
- Traversal guard simplified to `startsWith('../')` — the normalized form is guaranteed POSIX after the fix.
- Captures the pattern in `.claude/agent-memory/review-review-cubic-reviewer/` so the cubic-reviewer subagent can recognize it next time. Per CLAUDE.md, agent-memory changes ship with the code change that produced them.

## Why this is a separate PR

#101 was merged at 2026-04-17T06:58:55Z but cubic's second-pass review (P2 on `path.normalize`) completed after the merge, so `df95077` landed on `main` without the POSIX fix. `ec15af2` was pushed to the merged branch but never made it to `main`. This PR brings that fix plus the agent-memory onto `main` in one commit.

## Test plan

- [x] `bun run --cwd packages/cli build` — clean
- [x] `bun run --cwd packages/cli lint` — clean
- [x] `bun run --cwd packages/cli test` — **505 pass, 0 fail** (2 new tests: backslash normalization in stored output, `..\escape` rejection on POSIX)
- [ ] CI green (Cloudflare Pages, Test CLI, codecov, cubic AI reviewer)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize `docsPaths` to POSIX forward slashes in the CLI so values in `ask.json` are consistent across platforms. Also tightens traversal checks and adds tests.

- **Bug Fixes**
  - In `packages/cli/src/commands/add.ts`, use `path.posix.normalize(trimmed.replaceAll('\\', '/'))` to store paths like `docs\api` and `docs/api` as `docs/api`.
  - Simplify traversal guard to `normalized === '..' || normalized.startsWith('../')` now that output is POSIX.
  - Add tests for backslash→slash normalization and rejecting `..\escape`.
  - Capture the normalization pattern in `.claude/agent-memory/review-review-cubic-reviewer/` for future reviews.

<sup>Written for commit 60ee4cc2e641b0508860f3355ee9000eea16011b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

