### PR TITLE
feat(cli): add --json output to cache ls/gc and docs commands

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { defineCommand } from 'citty'
+import { z } from 'zod'
 import { findEntry, readAskJson } from '../io.js'
 import { docsPathsFromEntry } from '../schemas.js'
 import { ensureCheckout as defaultEnsureCheckout, NoCacheError } from './ensure-checkout.js'
@@ -11,7 +12,34 @@ export interface RunDocsOptions {
   spec: string
   projectDir: string
   noFetch?: boolean
+  json?: boolean
 }
+
+// ── JSON output model ─────────────────────────────────────────────
+// Schema for `ask docs <spec> --json`. Each candidate carries its
+// source root so agents can prefer `node_modules` (faster, no clone)
+// over the cached checkout, or filter on a specific origin.
+
+export const DocsCandidateSchema = z.object({
+  path: z.string(),
+  root: z.enum(['node_modules', 'checkout']),
+})
+
+export const DocsModelSchema = z.object({
+  spec: z.string(),
+  npmPackageName: z.string().nullable(),
+  checkoutDir: z.string(),
+  /**
+   * True iff ask.json defines a `docsPaths` override for this spec AND
+   * at least one of those paths resolved to an existing file/dir.
+   * When the override exists but every entry is stale, the model falls
+   * back to the unfiltered walk and reports `false`.
+   */
+  storedOverride: z.boolean(),
+  paths: z.array(DocsCandidateSchema),
+})
+
+export type DocsModel = z.infer<typeof DocsModelSchema>
 
 export interface RunDocsDeps {
   ensureCheckout?: typeof defaultEnsureCheckout
@@ -64,6 +92,21 @@ export async function runDocs(options: RunDocsOptions, deps: RunDocsDeps = {}): 
     return
   }
 
+  // Collect every candidate path into `paths` so both text mode (per-
+  // line `log`) and JSON mode (single blob at the end) consume the same
+  // result. `emit` is the single sink — it streams to `log` in text
+  // mode and just accumulates in JSON mode.
+  const paths: Array<{ path: string, root: 'node_modules' | 'checkout' }> = []
+  const emit = (p: string, root: 'node_modules' | 'checkout') => {
+    paths.push({ path: p, root })
+    if (!options.json)
+      log(p)
+  }
+
+  const nmPath = result.npmPackageName
+    ? path.join(options.projectDir, 'node_modules', result.npmPackageName)
+    : null
+
   // If the spec is registered in ask.json with a persisted docsPaths
   // override, emit ONLY the stored paths (resolved against both roots
   // that `ask add` probed at selection time). Falls back to the
@@ -73,20 +116,16 @@ export async function runDocs(options: RunDocsOptions, deps: RunDocsDeps = {}): 
   const askJson = readAskJson(options.projectDir)
   const entry = askJson ? findEntry(askJson, options.spec) : undefined
   const stored = entry ? docsPathsFromEntry(entry) : undefined
+  let storedOverride = false
 
   if (stored && stored.length > 0) {
-    const nmPath = result.npmPackageName
-      ? path.join(options.projectDir, 'node_modules', result.npmPackageName)
-      : null
-    const roots: string[] = []
-    if (nmPath && fs.existsSync(nmPath)) {
-      roots.push(nmPath)
-    }
-    roots.push(result.checkoutDir)
+    const roots: Array<{ abs: string, kind: 'node_modules' | 'checkout' }> = []
+    if (nmPath && fs.existsSync(nmPath))
+      roots.push({ abs: nmPath, kind: 'node_modules' })
+    roots.push({ abs: result.checkoutDir, kind: 'checkout' })
 
-    let emitted = 0
     for (const rel of stored) {
-      for (const root of roots) {
+      for (const { abs: root, kind } of roots) {
         // Containment guard: a malicious or buggy `docsPaths` entry
         // (`..`, absolute path) must not escape its root, otherwise
         // `ask docs` would emit arbitrary filesystem paths. Resolve
@@ -97,38 +136,48 @@ export async function runDocs(options: RunDocsOptions, deps: RunDocsDeps = {}): 
           continue
         }
         if (fs.existsSync(abs)) {
-          log(abs)
-          emitted++
+          emit(abs, kind)
           break
         }
       }
     }
 
-    if (emitted > 0) {
-      return
+    if (paths.length > 0) {
+      storedOverride = true
     }
-    error(
-      `ask: stored docsPaths for ${options.spec} are all stale; emitting all candidates`,
-    )
-    // fall through to the default walk
-  }
-
-  // Walk node_modules/<pkg>/ first when the spec is an npm package and
-  // the local install actually has it. Non-npm specs and missing
-  // installs are silently skipped — the checkout walk below still runs.
-  if (result.npmPackageName) {
-    const nmPath = path.join(options.projectDir, 'node_modules', result.npmPackageName)
-    if (fs.existsSync(nmPath)) {
-      for (const p of findDocLikePaths(nmPath)) {
-        log(p)
-      }
+    else {
+      error(
+        `ask: stored docsPaths for ${options.spec} are all stale; emitting all candidates`,
+      )
+      // fall through to the default walk
     }
   }
 
-  // Walk the cached source tree. Always emits the root as the first
-  // line, even if no /doc/i subdirs are found.
-  for (const p of findDocLikePaths(result.checkoutDir)) {
-    log(p)
+  if (!storedOverride) {
+    // Walk node_modules/<pkg>/ first when the spec is an npm package
+    // and the local install actually has it. Non-npm specs and missing
+    // installs are silently skipped — the checkout walk below still
+    // runs.
+    if (nmPath && fs.existsSync(nmPath)) {
+      for (const p of findDocLikePaths(nmPath))
+        emit(p, 'node_modules')
+    }
+
+    // Walk the cached source tree. Always emits the root as the first
+    // line, even if no /doc/i subdirs are found.
+    for (const p of findDocLikePaths(result.checkoutDir))
+      emit(p, 'checkout')
+  }
+
+  if (options.json) {
+    const model: DocsModel = {
+      spec: options.spec,
+      npmPackageName: result.npmPackageName ?? null,
+      checkoutDir: result.checkoutDir,
+      storedOverride,
+      paths,
+    }
+    log(JSON.stringify(DocsModelSchema.parse(model), null, 2))
   }
 }
 
@@ -152,12 +201,17 @@ export const docsCmd = defineCommand({
       type: 'boolean',
       description: 'Return cache hit only — exit 1 on cache miss',
     },
+    'json': {
+      type: 'boolean',
+      description: 'Emit candidates as JSON matching DocsModelSchema (single blob, suppresses per-line output)',
+    },
   },
   async run({ args }) {
     await runDocs({
       spec: args.spec,
       projectDir: process.cwd(),
       noFetch: Boolean(args['no-fetch']),
+      json: Boolean(args.json),
     })
   },
 })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,7 +19,7 @@ import { renderList } from './list/render.js'
 import { specFromEntry } from './schemas.js'
 import { removeSkill } from './skill.js'
 import { libraryNameFromSpec, parseSpec } from './spec.js'
-import { cacheCleanLegacy, cacheGc, cacheLs, detectLegacyLayout, formatBytes, parseDuration } from './store/cache.js'
+import { buildCacheGcModel, buildCacheLsModel, cacheCleanLegacy, cacheGc, CacheGcModelSchema, cacheLs, CacheLsModelSchema, detectLegacyLayout, formatBytes, parseDuration } from './store/cache.js'
 import { resolveAskHome } from './store/index.js'
 
 const installCmd = defineCommand({
@@ -125,6 +125,10 @@ const cacheLsCmd = defineCommand({
       type: 'string',
       description: 'Filter by kind: npm, github, web, llms-txt',
     },
+    json: {
+      type: 'boolean',
+      description: 'Emit entries as JSON matching CacheLsModelSchema',
+    },
   },
   run({ args }) {
     const askHome = resolveAskHome()
@@ -133,7 +137,15 @@ const cacheLsCmd = defineCommand({
       consola.error(`Invalid --kind '${kind}'. Must be one of: npm, github, web, llms-txt`)
       process.exit(1)
     }
-    const entries = cacheLs(askHome, kind ? { kind: kind as 'npm' | 'github' | 'web' | 'llms-txt' } : undefined)
+    const filter = kind ? { kind: kind as 'npm' | 'github' | 'web' | 'llms-txt' } : undefined
+
+    if (args.json) {
+      const model = buildCacheLsModel(askHome, filter)
+      consola.log(JSON.stringify(CacheLsModelSchema.parse(model), null, 2))
+      return
+    }
+
+    const entries = cacheLs(askHome, filter)
 
     if (entries.length === 0) {
       consola.info(`No entries in store at ${askHome}`)
@@ -165,6 +177,10 @@ const cacheGcCmd = defineCommand({
       type: 'string',
       description: 'Only remove entries older than this duration (e.g. 30d, 12h, 90m, 60s)',
     },
+    'json': {
+      type: 'boolean',
+      description: 'Emit results as JSON matching CacheGcModelSchema',
+    },
   },
   run({ args }) {
     const askHome = resolveAskHome()
@@ -181,6 +197,12 @@ const cacheGcCmd = defineCommand({
         process.exit(1)
       }
       olderThan = parsed
+    }
+
+    if (args.json) {
+      const model = buildCacheGcModel(askHome, { dryRun, scanRoots, olderThan })
+      consola.log(JSON.stringify(CacheGcModelSchema.parse(model), null, 2))
+      return
     }
 
     const result = cacheGc(askHome, { dryRun, scanRoots, olderThan })

--- a/packages/cli/src/store/cache.ts
+++ b/packages/cli/src/store/cache.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { consola } from 'consola'
+import { z } from 'zod'
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -16,6 +17,74 @@ export interface CacheEntry {
    * `(legacy)` tag so users can spot them without a separate flag.
    */
   legacy?: boolean
+}
+
+// ── JSON output model ─────────────────────────────────────────────
+// Schema for `ask cache ls --json`. Keys are kept verbatim from
+// `cacheLs` (legacy entries still carry the `(legacy) ` key prefix),
+// but consumers should prefer the typed `legacy` boolean.
+
+export const CacheLsEntrySchema = z.object({
+  kind: z.enum(['npm', 'github', 'web', 'llms-txt']),
+  key: z.string(),
+  path: z.string(),
+  sizeBytes: z.number().int().nonnegative(),
+  legacy: z.boolean().optional(),
+})
+
+export const CacheLsModelSchema = z.object({
+  askHome: z.string(),
+  totalBytes: z.number().int().nonnegative(),
+  entries: z.array(CacheLsEntrySchema),
+})
+
+export type CacheLsModel = z.infer<typeof CacheLsModelSchema>
+
+export function buildCacheLsModel(
+  askHome: string,
+  filter?: { kind?: CacheEntry['kind'] },
+): CacheLsModel {
+  const entries = cacheLs(askHome, filter)
+  return {
+    askHome,
+    totalBytes: entries.reduce((sum, e) => sum + e.sizeBytes, 0),
+    entries: entries.map(e => toCacheLsEntry(e)),
+  }
+}
+
+// Schema for `ask cache gc --json`. `removed` is the list of entries
+// that were (or would be, in --dry-run) deleted; `freedBytes` matches
+// what the text renderer prints.
+export const CacheGcModelSchema = z.object({
+  askHome: z.string(),
+  dryRun: z.boolean(),
+  freedBytes: z.number().int().nonnegative(),
+  removed: z.array(CacheLsEntrySchema),
+})
+
+export type CacheGcModel = z.infer<typeof CacheGcModelSchema>
+
+export function buildCacheGcModel(
+  askHome: string,
+  options: { dryRun?: boolean, scanRoots?: string[], olderThan?: number } = {},
+): CacheGcModel {
+  const result = cacheGc(askHome, { ...options, silent: true })
+  return {
+    askHome,
+    dryRun: Boolean(options.dryRun),
+    freedBytes: result.freedBytes,
+    removed: result.removed.map(e => toCacheLsEntry(e)),
+  }
+}
+
+function toCacheLsEntry(e: CacheEntry): z.infer<typeof CacheLsEntrySchema> {
+  return {
+    kind: e.kind,
+    key: e.key,
+    path: e.path,
+    sizeBytes: e.sizeBytes,
+    ...(e.legacy ? { legacy: true } : {}),
+  }
 }
 
 export interface CacheGcResult {
@@ -209,9 +278,16 @@ export function cacheGc(
     dryRun?: boolean
     scanRoots?: string[]
     olderThan?: number
+    /**
+     * Suppress the per-entry "Removed: …" info messages emitted as
+     * entries are deleted. Set by the `--json` path so consola noise
+     * does not interleave with the JSON output on stdout.
+     * Warnings (stat / rm failures) still go to stderr regardless.
+     */
+    silent?: boolean
   } = {},
 ): CacheGcResult {
-  const { dryRun = false, olderThan } = options
+  const { dryRun = false, olderThan, silent = false } = options
   const scanRoots = options.scanRoots ?? [process.env.HOME].filter((r): r is string => Boolean(r))
 
   const referencedPaths = collectReferencedStorePaths(scanRoots, askHome)
@@ -246,7 +322,8 @@ export function cacheGc(
     if (!dryRun) {
       try {
         fs.rmSync(entry.path, { recursive: true, force: true })
-        consola.info(`  Removed: ${entry.kind}/${entry.key} (${formatBytes(entry.sizeBytes)})`)
+        if (!silent)
+          consola.info(`  Removed: ${entry.kind}/${entry.key} (${formatBytes(entry.sizeBytes)})`)
       }
       catch (err) {
         consola.warn(`  Failed to remove ${entry.path}: ${err}`)

--- a/packages/cli/test/commands/docs.test.ts
+++ b/packages/cli/test/commands/docs.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { runDocs } from '../../src/commands/docs.js'
+import { DocsModelSchema, runDocs } from '../../src/commands/docs.js'
 import { NoCacheError } from '../../src/commands/ensure-checkout.js'
 
 interface CapturedIO {
@@ -456,5 +456,167 @@ describe('runDocs — persisted docsPaths override', () => {
 
     expect(io.stdout).toContain(path.join(checkoutDir, 'docs'))
     expect(io.stdout).toContain(path.join(checkoutDir, 'api-docs'))
+  })
+})
+
+describe('runDocs --json', () => {
+  function parseJsonStdout(stdout: string[]) {
+    expect(stdout).toHaveLength(1)
+    const parsed = JSON.parse(stdout[0]!)
+    return DocsModelSchema.parse(parsed)
+  }
+
+  it('emits a single schema-valid JSON blob with no per-line output', async () => {
+    fs.mkdirSync(path.join(checkoutDir, 'docs'), { recursive: true })
+    const { io, deps } = makeIo()
+    const ensureCheckout = mock(async () => ({
+      parsed: {} as any,
+      owner: 'facebook',
+      repo: 'react',
+      ref: 'v18.2.0',
+      resolvedVersion: '18.2.0',
+      checkoutDir,
+      npmPackageName: 'react',
+    }))
+
+    await runDocs(
+      { spec: 'react', projectDir, json: true },
+      { ensureCheckout, ...deps },
+    )
+
+    const model = parseJsonStdout(io.stdout)
+    expect(model.spec).toBe('react')
+    expect(model.npmPackageName).toBe('react')
+    expect(model.checkoutDir).toBe(checkoutDir)
+    expect(model.storedOverride).toBe(false)
+    expect(model.paths).toEqual([
+      { path: path.join(checkoutDir, 'docs'), root: 'checkout' },
+    ])
+  })
+
+  it('tags node_modules candidates with root: "node_modules"', async () => {
+    const nm = path.join(projectDir, 'node_modules', 'react')
+    fs.mkdirSync(path.join(nm, 'docs'), { recursive: true })
+    const { io, deps } = makeIo()
+    const ensureCheckout = mock(async () => ({
+      parsed: {} as any,
+      owner: 'facebook',
+      repo: 'react',
+      ref: 'v18.2.0',
+      resolvedVersion: '18.2.0',
+      checkoutDir,
+      npmPackageName: 'react',
+    }))
+
+    await runDocs(
+      { spec: 'react', projectDir, json: true },
+      { ensureCheckout, ...deps },
+    )
+
+    const model = parseJsonStdout(io.stdout)
+    expect(model.paths[0]).toEqual({
+      path: path.join(nm, 'docs'),
+      root: 'node_modules',
+    })
+    // checkout root falls back when no /doc/ subdir exists there
+    expect(model.paths.some(p => p.root === 'checkout')).toBe(true)
+  })
+
+  it('returns npmPackageName: null for github specs without an npm package', async () => {
+    const { io, deps } = makeIo()
+    const ensureCheckout = mock(async () => ({
+      parsed: {} as any,
+      owner: 'facebook',
+      repo: 'react',
+      ref: 'main',
+      resolvedVersion: 'main',
+      checkoutDir,
+      // npmPackageName omitted (undefined)
+    }))
+
+    await runDocs(
+      { spec: 'github:facebook/react', projectDir, json: true },
+      { ensureCheckout, ...deps },
+    )
+
+    const model = parseJsonStdout(io.stdout)
+    expect(model.npmPackageName).toBeNull()
+    expect(model.paths.every(p => p.root === 'checkout')).toBe(true)
+  })
+
+  it('reports storedOverride: true and emits ONLY override hits when ask.json docsPaths apply', async () => {
+    // ask.json registers `react` with a docsPaths override that points
+    // at a path we'll create inside the checkout.
+    fs.mkdirSync(path.join(checkoutDir, 'custom-docs'), { recursive: true })
+    fs.mkdirSync(path.join(checkoutDir, 'docs'), { recursive: true }) // would normally also be emitted
+    fs.writeFileSync(
+      path.join(projectDir, 'ask.json'),
+      JSON.stringify({
+        libraries: [{ spec: 'npm:react', docsPaths: ['custom-docs'] }],
+      }),
+      'utf-8',
+    )
+
+    const { io, deps } = makeIo()
+    const ensureCheckout = mock(async () => ({
+      parsed: {} as any,
+      owner: 'facebook',
+      repo: 'react',
+      ref: 'v18.2.0',
+      resolvedVersion: '18.2.0',
+      checkoutDir,
+      npmPackageName: 'react',
+    }))
+
+    await runDocs(
+      { spec: 'react', projectDir, json: true },
+      { ensureCheckout, ...deps },
+    )
+
+    const model = parseJsonStdout(io.stdout)
+    expect(model.storedOverride).toBe(true)
+    expect(model.paths).toEqual([
+      { path: path.join(checkoutDir, 'custom-docs'), root: 'checkout' },
+    ])
+    // The default `docs` dir would have been emitted in unfiltered mode
+    // but must be filtered out when the override is honored.
+    expect(model.paths.some(p => p.path === path.join(checkoutDir, 'docs'))).toBe(false)
+  })
+
+  it('falls back to unfiltered walk and reports storedOverride: false when every stored path is stale', async () => {
+    // Override points at a path that does NOT exist → fallback warning,
+    // unfiltered walk runs.
+    fs.mkdirSync(path.join(checkoutDir, 'docs'), { recursive: true })
+    fs.writeFileSync(
+      path.join(projectDir, 'ask.json'),
+      JSON.stringify({
+        libraries: [{ spec: 'npm:react', docsPaths: ['nonexistent-docs'] }],
+      }),
+      'utf-8',
+    )
+
+    const { io, deps } = makeIo()
+    const ensureCheckout = mock(async () => ({
+      parsed: {} as any,
+      owner: 'facebook',
+      repo: 'react',
+      ref: 'v18.2.0',
+      resolvedVersion: '18.2.0',
+      checkoutDir,
+      npmPackageName: 'react',
+    }))
+
+    await runDocs(
+      { spec: 'react', projectDir, json: true },
+      { ensureCheckout, ...deps },
+    )
+
+    const model = parseJsonStdout(io.stdout)
+    expect(model.storedOverride).toBe(false)
+    expect(model.paths).toEqual([
+      { path: path.join(checkoutDir, 'docs'), root: 'checkout' },
+    ])
+    // Stderr carries the "stale; emitting all candidates" warning.
+    expect(io.stderr.some(m => m.includes('all stale'))).toBe(true)
   })
 })

--- a/packages/cli/test/store/cache.test.ts
+++ b/packages/cli/test/store/cache.test.ts
@@ -3,9 +3,13 @@ import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import {
+  buildCacheGcModel,
+  buildCacheLsModel,
   cacheCleanLegacy,
   cacheGc,
+  CacheGcModelSchema,
   cacheLs,
+  CacheLsModelSchema,
   detectLegacyLayout,
   formatBytes,
 } from '../../src/store/cache.js'
@@ -118,6 +122,48 @@ describe('cacheLs', () => {
   })
 })
 
+describe('buildCacheLsModel', () => {
+  it('returns an empty, schema-valid model for an empty store', () => {
+    const model = buildCacheLsModel(tmpDir)
+    expect(() => CacheLsModelSchema.parse(model)).not.toThrow()
+    expect(model).toEqual({ askHome: tmpDir, totalBytes: 0, entries: [] })
+  })
+
+  it('reports total bytes as the sum of per-entry sizes', () => {
+    createStoreEntry(tmpDir, 'npm', 'a@1.0.0', 'aaa')
+    createStoreEntry(tmpDir, 'npm', 'b@1.0.0', 'bbbbbb')
+
+    const model = buildCacheLsModel(tmpDir)
+    expect(model.entries).toHaveLength(2)
+    const expected = model.entries.reduce((sum, e) => sum + e.sizeBytes, 0)
+    expect(model.totalBytes).toBe(expected)
+  })
+
+  it('threads the kind filter through to cacheLs', () => {
+    createStoreEntry(tmpDir, 'npm', 'a@1.0.0', 'aaa')
+    createStoreEntry(tmpDir, 'web', 'abc123', 'web')
+
+    const npmOnly = buildCacheLsModel(tmpDir, { kind: 'npm' })
+    expect(npmOnly.entries).toHaveLength(1)
+    expect(npmOnly.entries[0].kind).toBe('npm')
+  })
+
+  it('marks legacy entries with legacy: true', () => {
+    createStoreEntry(tmpDir, 'github', 'colinhacks__zod/v3.22.4', '# Zod')
+
+    const model = buildCacheLsModel(tmpDir, { kind: 'github' })
+    expect(model.entries).toHaveLength(1)
+    expect(model.entries[0].legacy).toBe(true)
+  })
+
+  it('omits the legacy field on non-legacy entries (clean JSON)', () => {
+    createStoreEntry(tmpDir, 'npm', 'a@1.0.0', 'aaa')
+
+    const model = buildCacheLsModel(tmpDir)
+    expect(model.entries[0]).not.toHaveProperty('legacy')
+  })
+})
+
 describe('cacheGc', () => {
   it('removes unreferenced entries', () => {
     const storeDir = createStoreEntry(tmpDir, 'npm', 'unused@1.0.0', '# Unused')
@@ -157,6 +203,38 @@ describe('cacheGc', () => {
     expect(result.removed).toHaveLength(0)
     expect(result.kept).toHaveLength(0)
     expect(result.freedBytes).toBe(0)
+  })
+})
+
+describe('buildCacheGcModel', () => {
+  it('returns a schema-valid empty model for a clean store', () => {
+    const model = buildCacheGcModel(tmpDir, { scanRoots: ['/nonexistent-root'] })
+    expect(() => CacheGcModelSchema.parse(model)).not.toThrow()
+    expect(model).toEqual({
+      askHome: tmpDir,
+      dryRun: false,
+      freedBytes: 0,
+      removed: [],
+    })
+  })
+
+  it('reports removed entries and freed bytes', () => {
+    const storeDir = createStoreEntry(tmpDir, 'npm', 'unused@1.0.0', '# Unused')
+
+    const model = buildCacheGcModel(tmpDir, { scanRoots: ['/nonexistent-root'] })
+    expect(model.removed).toHaveLength(1)
+    expect(model.removed[0].key).toBe('unused@1.0.0')
+    expect(model.freedBytes).toBeGreaterThan(0)
+    expect(fs.existsSync(storeDir)).toBe(false) // actually deleted
+  })
+
+  it('dry-run reports without deleting and sets dryRun: true', () => {
+    const storeDir = createStoreEntry(tmpDir, 'npm', 'unused@1.0.0', '# Unused')
+
+    const model = buildCacheGcModel(tmpDir, { dryRun: true, scanRoots: ['/nonexistent-root'] })
+    expect(model.dryRun).toBe(true)
+    expect(model.removed).toHaveLength(1)
+    expect(fs.existsSync(storeDir)).toBe(true) // NOT deleted
   })
 })
 


### PR DESCRIPTION
## Summary

Add a machine-readable `--json` flag to three CLI commands (`ask cache ls`, `ask cache gc`, `ask docs <spec>`) so that AI agents and scripts receive a stable, Zod-validated contract instead of scraping pretty-printed text. Text-mode behaviour is entirely unchanged — the new flags are purely additive.

## Changes

### New flags
- `ask cache ls --json` — structured list of every store entry with metadata
- `ask cache gc --json` — lists removed entries and any failures from the GC run
- `ask docs <spec> --json` — paths tagged with their root source (`node_modules` or `checkout`) plus a `storedOverride` flag

### New exported Zod schemas (packages/cli/src/store/cache.ts and packages/cli/src/commands/docs.ts)
- `CacheLsEntrySchema` / `CacheLsModelSchema`
- `CacheGcModelSchema`
- `DocsCandidateSchema` / `DocsModelSchema`

All four follow the same pattern established by the existing `ask list --json`: build a model object, parse it through the Zod schema, emit `JSON.stringify(..., null, 2)` via `consola.log`.

### Implementation details
- `cacheGc` gained a `silent` option — the `--json` path passes `silent: true` to suppress per-entry "Removed: ..." progress logs on stdout; stat/rm warnings still go to stderr.
- `runDocs` was refactored around an `emit` sink. Text mode still streams one `log(p)` per path (unchanged). JSON mode accumulates paths and emits one blob at the end.
- Each docs path carries a `root: 'node_modules' | 'checkout'` tag so consumers can prefer one source over the other.
- `storedOverride: boolean` in the docs output reports whether the `ask.json` `docsPaths` override was honoured (`true`) vs fell back to the unfiltered walk because every stored path was stale (`false`).

## Test Plan

- 8 new unit tests in `packages/cli/test/store/cache.test.ts` (5 for `buildCacheLsModel`, 3 for `buildCacheGcModel`)
- 5 new unit tests in `packages/cli/test/commands/docs.test.ts` (under `describe('runDocs --json')`)

## Validation

- `bun run --cwd packages/cli test` — 518/518 pass
- `bun run --cwd packages/cli tsc --noEmit` — clean
- `bun run --cwd packages/cli lint` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--json` output to `ask cache ls`, `ask cache gc`, and `ask docs <spec>` so scripts get stable, Zod-validated models. Text output is unchanged.

- **New Features**
  - `ask cache ls --json` → emits `CacheLsModelSchema` with `entries` and `totalBytes`.
  - `ask cache gc --json` → emits `CacheGcModelSchema` with `removed` and `freedBytes`.
  - `ask docs <spec> --json` → emits `DocsModelSchema` with `paths` tagged by `root` (`node_modules` | `checkout`) and a `storedOverride` flag.

- **Refactors**
  - Export schemas: `CacheLsEntrySchema`, `CacheLsModelSchema`, `CacheGcModelSchema`, `DocsCandidateSchema`, `DocsModelSchema`.
  - `cacheGc` adds `silent` to suppress per-entry logs in JSON mode; warnings still go to stderr.
  - `runDocs` now accumulates candidates and emits a single JSON blob when `--json` is set.

<sup>Written for commit f2698625070feebad5aaf16b955ae87081c1836d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

