### PR TITLE
fix(cloudflare): relocate wrangler.jsonc into apps/registry/

### DIFF
--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -7,7 +7,7 @@
     "build:node": "nuxt build",
     "dev": "nuxt dev",
     "preview": "nuxt preview",
-    "preview:cf": "wrangler pages dev --config ../../wrangler.jsonc",
+    "preview:cf": "wrangler pages dev",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "vitest run",

--- a/apps/registry/wrangler.jsonc
+++ b/apps/registry/wrangler.jsonc
@@ -2,9 +2,10 @@
 //
 // This file serves two purposes:
 //
-//   1. `wrangler pages dev` (local preview, via `bun run --cwd apps/registry preview:cf`) reads it to
-//      mount the D1 binding `DB` against the real Cloudflare database
-//      used by production. That is the only way to exercise the
+//   1. `wrangler pages dev` (local preview, via
+//      `bun run --cwd apps/registry preview:cf`) reads it to mount the D1
+//      binding `DB` against the real Cloudflare database used by
+//      production. That is the only way to exercise the
 //      `content.database = { type: 'd1', bindingName: 'DB' }` branch of
 //      `nuxt.config.ts` on a developer machine.
 //
@@ -19,18 +20,24 @@
 //      and prevents a silent regression if the dashboard binding is ever
 //      removed.
 //
+// Cloudflare Pages project setup (must match this file):
+//   - Root directory:       apps/registry
+//   - Build command:        cd ../.. && bun install && bun run build -- --filter=@pleaseai/ask-registry
+//                           (turbo's `^build` dep makes schema build first)
+//   - Build output dir:     dist            (resolved under Root directory)
+//
 // Note: Cloudflare Pages also accepts bindings configured through the
 // dashboard UI. The values here should match what the dashboard sets so
 // both entry points agree.
 {
-  "$schema": "apps/registry/node_modules/wrangler/config-schema.json",
+  "$schema": "node_modules/wrangler/config-schema.json",
   "name": "ask-registry",
   "compatibility_date": "2026-04-03",
-  // Nitro's `cloudflare_pages` preset emits registry assets to
-  // `apps/registry/dist/`. Cloudflare Pages runs with the repo root as
-  // its Root directory so turbo can build the schema workspace dep
-  // before Nuxt; the output path is relative to that root.
-  "pages_build_output_dir": "apps/registry/dist",
+  // Resolved relative to the Cloudflare Pages "Root directory" setting,
+  // which must be `apps/registry`. Nitro's `cloudflare_pages` preset
+  // emits the registry assets to `apps/registry/dist/`, i.e. `dist/` from
+  // this file's perspective.
+  "pages_build_output_dir": "dist",
   "d1_databases": [
     {
       "binding": "DB",


### PR DESCRIPTION
## What
- Move `wrangler.jsonc` from the repo root into `apps/registry/wrangler.jsonc`
- Adjust `pages_build_output_dir`: `apps/registry/dist` → `dist` (now resolved under the new Root directory)
- Adjust `$schema` path: `apps/registry/node_modules/wrangler/config-schema.json` → `node_modules/wrangler/config-schema.json`
- Drop `--config ../../wrangler.jsonc` from `apps/registry`'s `preview:cf` script (same-folder auto-detection)
- Comment block in the new file documents the required Cloudflare Pages project settings

## Why
The previous `ask-docs` Cloudflare Pages build failed with `Error: Output directory "apps/registry/dist" not found.` because Pages auto-detected the **root** `wrangler.jsonc` (registry-scoped) while the build command targeted `apps/docs`. With each project's wrangler file living next to its own project, the cross-project leak disappears.

## ⚠️ Required Cloudflare Pages dashboard changes (paired with this PR)

This PR will not unblock the deploy on its own. After merge, update both Pages projects:

### `ask-registry`
- **Root directory**: `/` → `apps/registry`
- **Build command** (one of):
  - `cd ../.. && bun install && bun run build -- --filter=@pleaseai/ask-registry`
  - `cd ../.. && bun install && turbo run build --filter=@pleaseai/ask-registry`

  (turbo's `dependsOn: ["^build"]` ensures `@pleaseai/ask-schema` builds first — required because the registry imports its `dist/` exports via `workspace:*`.)
- **Build output directory**: `dist`

### `ask-docs`
- **Root directory**: `/` → `apps/docs` (uses the existing `apps/docs/wrangler.jsonc`)
- **Build command**: `cd ../.. && bun install && bun run --cwd apps/docs build`

  (Still routes through the repo-root `bun install` so the hoisted `node_modules`, root `postinstall` h3 cleanup, and `docs-please` patch all apply.)

## Verification plan
1. Open this PR; both Pages projects build a **Preview** deployment for the branch.
2. Confirm both preview URLs render correctly before promoting to production.
3. If either preview fails, do **not** merge — revert the dashboard settings, since this PR + dashboard changes are a single logical unit.

## Why option 2 over option 1 (kept ask-docs Root = repo root)
Option 1 (only changing ask-docs Root directory) would have fixed the immediate failure with no code changes, but it left the asymmetry — registry config at repo root, docs config inside its app folder. Option 2 makes both projects symmetric (each has its own `apps/<name>/wrangler.jsonc`) at the cost of also moving the registry's Cloudflare Pages Root, which requires a non-trivial Build command change to preserve the schema workspace dep build order. The trade-off was discussed and option 2 was chosen for the cleaner long-term shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Cloudflare Pages `wrangler.jsonc` into `apps/registry/` and updated paths to stop `ask-docs` from picking up registry config. This fixes the “output directory not found” error and simplifies local `wrangler` preview.

- **Migration**
  - ask-registry: Root=apps/registry; Build=`cd ../.. && bun install && bun run build -- --filter=@pleaseai/ask-registry`; Output=dist
  - ask-docs: Root=apps/docs; Build=`cd ../.. && bun install && bun run --cwd apps/docs build`

<sup>Written for commit 034d87da6d10163fe7935253705ea42f8b06dd14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

