### PR TITLE
Add a Codacy badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ASK (Agent Skills Kit)
 
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/bbd8fab3461e4f17bfaf94793645a5be)](https://app.codacy.com/gh/pleaseai/ask?utm_source=github.com&utm_medium=referral&utm_content=pleaseai/ask&utm_campaign=Badge_Grade)
+
 Download version-specific library documentation for AI coding agents.
 
 Inspired by [Next.js evals](https://nextjs.org/evals) showing that providing `AGENTS.md` with bundled docs dramatically improves AI agent performance (Claude Opus 4.6: 71% → 100%), ASK generalizes this pattern to any library.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Codacy code quality badge to README.md to display the current grade and link to the Codacy dashboard. Improves visibility of code quality status on GitHub at a glance.

<sup>Written for commit 3e40bc48bf77a1672a23609fd0c6a59eb93ac553. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

