### PR TITLE
chore: bump bun to 1.3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "turbo": "^2",
     "yaml": "^2.8.3"
   },
-  "packageManager": "bun@1.3.11",
+  "packageManager": "bun@1.3.14",
   "trustedDependencies": [
     "@parcel/watcher"
   ],


### PR DESCRIPTION
## Summary

Bumps the pinned Bun version from 1.3.11 to 1.3.14 across the repository.

## Changes

- `package.json`: Updated `packageManager` field from `bun@1.3.11` to `bun@1.3.14`
- `.github/workflows/release.yml`: Updated `bun-version` in the `setup-bun` step from `1.3.11` to `1.3.14`

## Why

Keeps the local development environment and the CI release pipeline pinned to the same Bun release, picking up bug fixes and improvements shipped in 1.3.12–1.3.14.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `bun` to 1.3.14 across the repo to keep local dev and CI aligned and pick up bug fixes from 1.3.12–1.3.14. Updates `packageManager` in package.json and `bun-version` in the release workflow.

<sup>Written for commit 314a660a6677de4c6e51e0db55021ec85f8ac561. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

