### PR TITLE
fix(npm): normalize repository.url to git+https form to silence npm publish warning

### DIFF
--- a/npm/ask/package.json
+++ b/npm/ask/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/pleaseai/ask",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pleaseai/ask.git"
+    "url": "git+https://github.com/pleaseai/ask.git"
   },
   "bugs": {
     "url": "https://github.com/pleaseai/ask/issues"


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Normalizes `repository.url` in `npm/ask/package.json` from `"https://github.com/pleaseai/ask.git"` to `"git+https://github.com/pleaseai/ask.git"` to silence the `npm warn publish "repository.url" was normalized` warning seen while publishing the npm platform packages for the ask-v0.4.9 Rust CLI release cutover. Generated platform packages inherit `repository` from this base `package.json`, so fixing it at the source prevents the warning on all future publishes.

## Related issue

No linked issue — standalone fix, not tied to a tracked GitHub issue.

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Tests added or updated, and the suite passes (`bun run --cwd packages/cli test`) — N/A, metadata-only change
- [ ] Lint/format pass (`bun run lint`) — N/A, metadata-only change
- [ ] Documentation updated if behavior changed — N/A, no behavior change
- [x] No breaking change, or a `BREAKING CHANGE:` note is included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized `repository.url` in `npm/ask/package.json` to `git+https://github.com/pleaseai/ask.git` to silence the npm publish warning and ensure generated platform packages inherit the correct repository URL.

<sup>Written for commit a0e9a41afcb347935371ae98f1474090fd779918. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

