### PR TITLE
chore: generate Codex, Cursor, and Antigravity plugin manifests

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "ask",
+  "version": "0.4.11",
+  "description": "ASK (Agent Skills Kit) — AI agent skills for managing library documentation registry entries",
+  "author": {
+    "name": "Minsu Lee",
+    "url": "https://github.com/amondnet"
+  },
+  "interface": {
+    "displayName": "Ask",
+    "shortDescription": "ASK (Agent Skills Kit) — AI agent skills for managing library documentation registry entries",
+    "longDescription": "ASK (Agent Skills Kit) — AI agent skills for managing library documentation registry entries",
+    "developerName": "Minsu Lee",
+    "category": "Development",
+    "capabilities": [
+      "Skill"
+    ],
+    "defaultPrompt": [
+      "Help me use Ask for my current task."
+    ],
+    "websiteURL": "https://github.com/pleaseai/ask"
+  },
+  "homepage": "https://github.com/pleaseai/ask",
+  "repository": "https://github.com/pleaseai/ask",
+  "license": "MIT",
+  "keywords": [
+    "documentation",
+    "registry",
+    "library",
+    "agent-skills",
+    "ask"
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "ask",
+  "displayName": "Ask",
+  "description": "ASK (Agent Skills Kit) — AI agent skills for managing library documentation registry entries",
+  "version": "0.4.11",
+  "author": {
+    "name": "Minsu Lee"
+  },
+  "category": "Development",
+  "homepage": "https://github.com/pleaseai/ask",
+  "repository": "https://github.com/pleaseai/ask",
+  "license": "MIT",
+  "keywords": [
+    "documentation",
+    "registry",
+    "library",
+    "agent-skills",
+    "ask"
+  ],
+  "tags": [
+    "tooling",
+    "documentation"
+  ]
+}

--- a/hooks.json
+++ b/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Suggest ask CLI commands when WebFetch targets GitHub or a known library docs site",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"./hooks/fetch-hint.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "ask",
+  "version": "0.4.11",
+  "description": "ASK (Agent Skills Kit) — AI agent skills for managing library documentation registry entries",
+  "author": {
+    "name": "Minsu Lee",
+    "url": "https://github.com/amondnet"
+  },
+  "homepage": "https://github.com/pleaseai/ask",
+  "repository": "https://github.com/pleaseai/ask",
+  "license": "MIT",
+  "keywords": [
+    "documentation",
+    "registry",
+    "library",
+    "agent-skills",
+    "ask"
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -40,6 +40,21 @@
           "type": "json",
           "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".cursor-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Generated via the plugin-dev plugin's multi-format generator, using `.claude-plugin/plugin.json` as the source of truth. Adds runtime manifests for the `ask` plugin so it loads in Codex, Cursor, and Antigravity in addition to Claude Code.

## Changes

- `.codex-plugin/plugin.json` — new Codex runtime manifest
- `.cursor-plugin/plugin.json` — new Cursor runtime manifest
- `plugin.json` — new Antigravity root manifest
- `hooks.json` — new Antigravity root hooks (mirrors `hooks/hooks.json`, with `${CLAUDE_PLUGIN_ROOT}/` rewritten to `./`)
- `release-please-config.json` — added the three new version-bearing manifests to the root `ask-plugin` package's `extra-files`, so their `$.version` stays synced with `.claude-plugin/plugin.json` on release

No MCP servers are declared for this plugin, so no `.mcp.json` was generated.

## Test Plan

- [x] Verified generated manifest JSON is well-formed and metadata (name, version, description, repo/homepage links) matches `.claude-plugin/plugin.json`
- [x] Confirmed `release-please-config.json` extra-files wiring includes all three new manifests

## Related Issues

None — no linked issue for this chore.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generated runtime manifests for the `ask` plugin so it loads in Codex, Cursor, and Antigravity, and synced their versions via `release-please`.

- **New Features**
  - Added `.codex-plugin/plugin.json` and `.cursor-plugin/plugin.json`.
  - Added Antigravity `plugin.json` and `hooks.json` (mirrors `hooks/hooks.json` with path rewrite).
  - Updated `release-please-config.json` to keep new manifests’ `$.version` aligned with `.claude-plugin/plugin.json`.

<sup>Written for commit 60091a11d53f49cf601392f0a4ec70e10f7d004a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

